### PR TITLE
fix: reduce influence of integer truncation on averaged downsamples

### DIFF
--- a/igneous/tasks.py
+++ b/igneous/tasks.py
@@ -60,9 +60,12 @@ def downsample_and_upload(
 
     downsamplefn = downsample.method(vol.layer_type, sparse=sparse)
 
+    if vol.layer_type == 'image':
+      image = image.astype(np.float32)
+
     vol.mip = mip
     if not skip_first:
-      vol[bounds.to_slices()] = image
+      vol[bounds.to_slices()] = image.astype(vol.dtype)
 
     new_bounds = bounds.clone()
 
@@ -71,7 +74,7 @@ def downsample_and_upload(
       image = downsamplefn(image, factor3)
       new_bounds //= factor3
       new_bounds.maxpt = new_bounds.minpt + Vec(*image.shape[:3])
-      vol[new_bounds.to_slices()] = image
+      vol[new_bounds.to_slices()] = image.astype(vol.dtype)
 
 
 def cache(task, cloudpath):

--- a/igneous/tasks.py
+++ b/igneous/tasks.py
@@ -60,7 +60,7 @@ def downsample_and_upload(
 
     downsamplefn = downsample.method(vol.layer_type, sparse=sparse)
 
-    if vol.layer_type == 'image':
+    if downsamplefn == downsample.downsample_with_averaging:
       image = image.astype(np.float32)
 
     vol.mip = mip

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -43,7 +43,7 @@ def test_ingest_image():
     cv.mip = 1
     assert np.all(cv[slice64] == data_ds1[slice64])
 
-    data_ds2 = downsample.downsample_with_averaging(data_ds1, factor=[2, 2, 1, 1])
+    data_ds2 = downsample.downsample_with_averaging(data, factor=[4, 4, 1, 1])
     cv.mip = 2
     assert np.all(cv[slice64] == data_ds2[slice64])
 
@@ -103,21 +103,21 @@ def test_downsample_no_offset():
     cv.mip = 0
     assert np.all(cv[slice64] == data[slice64])
 
-    data_ds1 = downsample.downsample_with_averaging(data, factor=[2, 2, 1, 1])
+    data_ds = downsample.downsample_with_averaging(data, factor=[2, 2, 1, 1])
     cv.mip = 1
-    assert np.all(cv[slice64] == data_ds1[slice64])
+    assert np.all(cv[slice64] == data_ds[slice64])
 
-    data_ds2 = downsample.downsample_with_averaging(data_ds1, factor=[2, 2, 1, 1])
+    data_ds = downsample.downsample_with_averaging(data, factor=[4, 4, 1, 1])
     cv.mip = 2
-    assert np.all(cv[slice64] == data_ds2[slice64])
+    assert np.all(cv[slice64] == data_ds[slice64])
 
-    data_ds3 = downsample.downsample_with_averaging(data_ds2, factor=[2, 2, 1, 1])
+    data_ds = downsample.downsample_with_averaging(data, factor=[8, 8, 1, 1])
     cv.mip = 3
-    assert np.all(cv[slice64] == data_ds3[slice64])
+    assert np.all(cv[slice64] == data_ds[slice64])
 
-    data_ds4 = downsample.downsample_with_averaging(data_ds3, factor=[2, 2, 1, 1])
+    data_ds = downsample.downsample_with_averaging(data, factor=[16, 16, 1, 1])
     cv.mip = 4
-    assert np.all(cv[slice64] == data_ds4[slice64])
+    assert np.all(cv[slice64] == data_ds[slice64])
 
 def test_downsample_with_offset():
     delete_layer()
@@ -143,17 +143,17 @@ def test_downsample_with_offset():
     cv.mip = 0
     assert np.all(cv[3:67, 7:71, 11:75] == data[0:64, 0:64, 0:64])
 
-    data_ds1 = downsample.downsample_with_averaging(data, factor=[2, 2, 1, 1])
+    data_ds = downsample.downsample_with_averaging(data, factor=[2, 2, 1, 1])
     cv.mip = 1
-    assert np.all(cv[1:33, 3:35, 11:75] == data_ds1[0:32, 0:32, 0:64])
+    assert np.all(cv[1:33, 3:35, 11:75] == data_ds[0:32, 0:32, 0:64])
 
-    data_ds2 = downsample.downsample_with_averaging(data_ds1, factor=[2, 2, 1, 1])
+    data_ds = downsample.downsample_with_averaging(data, factor=[4, 4, 1, 1])
     cv.mip = 2
-    assert np.all(cv[0:16, 1:17, 11:75] == data_ds2[0:16, 0:16, 0:64])
+    assert np.all(cv[0:16, 1:17, 11:75] == data_ds[0:16, 0:16, 0:64])
 
-    data_ds3 = downsample.downsample_with_averaging(data_ds2, factor=[2, 2, 1, 1])
+    data_ds = downsample.downsample_with_averaging(data, factor=[8, 8, 1, 1])
     cv.mip = 3
-    assert np.all(cv[0:8, 0:8, 11:75] == data_ds3[0:8,0:8,0:64])
+    assert np.all(cv[0:8, 0:8, 11:75] == data_ds[0:8,0:8,0:64])
 
 def test_downsample_w_missing():
     delete_layer()


### PR DESCRIPTION
Iterative downsample_with_averaging has the advantage that each level
of downsampling is a fourth the size of the original mip level. However,
as most image datasets are integer types, we were previously losing up
to a unit of luminance on each mip level due to integer truncation.

While this is difficult to avoid for superdownsamples, we can avoid it
while maintaining this desirable logarithmic time complexity by averaging
floats and writing integers at each mip level, limiting the total loss
of pixel luminance to at most 1 across all mip levels in a given task.