### PR TITLE
refactor(Dockerfile): Reduce Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+dist
+build
+igneous.egg-info
+*.so
+.eggs
+*.pyc
+__pycache__
+.cache
+test.py
+pipeline.py
+.pytest_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,25 @@
-FROM python:3.6
-MAINTAINER William Silversmith
-# This image contains private keys, make sure the image is not pushed to docker hub or any public repo.
+FROM python:3.6-slim
+LABEL maintainer="William Silversmith, Nico Kemnitz"
 
-# Prepare the image.
-ENV DEBIAN_FRONTEND noninteractive
 ADD ./ /igneous
-RUN apt update \
+RUN apt-get update \
     # Build dependencies
-    && apt install -y -qq --no-install-recommends \
+    && apt-get install -y -qq --no-install-recommends \
+        git \
         libboost-dev \
-    && pip install --no-cache-dir \
-        Cython \
-    \
+        build-essential \
     # igneous + runtime dependencies
     && cd igneous \
     && pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir -e . \
     \
     # Cleanup build dependencies
-    && apt remove --purge -y \
+    && apt-get remove --purge -y \
         libboost-dev \
-    && apt autoremove --purge -y \
+        build-essential \
+    && apt-get autoremove --purge -y \
     # Cleanup apt
-    && apt clean \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     # Cleanup temporary python files
     && find /usr/local/lib/python3.6 -depth \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,35 @@
 FROM python:3.6
 MAINTAINER William Silversmith
 # This image contains private keys, make sure the image is not pushed to docker hub or any public repo.
-## INSTALL gsutil
+
 # Prepare the image.
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y -qq --no-install-recommends \
-    apt-utils \
-    curl \
-    git \
-    openssh-client \
-    python-openssl \
-    python \
-    python-pip \
-    python-dev \
-#    python-h5py \
-    python-numpy \
-    python-setuptools \
-    libboost-all-dev \
-#    libhdf5-dev \
-    liblzma-dev \
-    libgmp-dev \
-#    libmpfr-dev \
-#    libxml2-dev \
-    screen \
-    software-properties-common \
-    unzip \
-    vim \
-    wget \
-    zlib1g-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install setuptools Cython wheel numpy 
-
-# install neuroglancer
-RUN mkdir /.ssh
 ADD ./ /igneous
-RUN pip install -r /igneous/requirements.txt \
-    && pip install pyasn1 --upgrade \
-    && cd /igneous && pip install -e .
+RUN apt update \
+    # Build dependencies
+    && apt install -y -qq --no-install-recommends \
+        libboost-dev \
+    && pip install --no-cache-dir \
+        Cython \
+    \
+    # igneous + runtime dependencies
+    && cd igneous \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir -e . \
+    \
+    # Cleanup build dependencies
+    && apt remove --purge -y \
+        libboost-dev \
+    && apt autoremove --purge -y \
+    # Cleanup apt
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/* \
+    # Cleanup temporary python files
+    && find /usr/local/lib/python3.6 -depth \
+      \( \
+        \( -type d -a \( -name __pycache__ \) \) \
+        -o \
+        \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+      \) -exec rm -rf '{}' +
 
 CMD python /igneous/igneous/task_execution.py
-
-
-
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ click>=6.7
 cloud-volume>=0.38.0
 google-cloud-logging
 numpy>=1.14.2
+Pillow>=4.2.1
 pytest>=3.3.1
 task-queue>=0.4.1
 -e git+https://github.com/seung-lab/tqdm.git#egg=tqdm
-oauth2client>=3.0.0
+oauth2client==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,8 @@
-backports.lzma==0.0.8
-click==6.7
-cryptography==2.3
+click>=6.7
 cloud-volume>=0.38.0
 google-cloud-logging
-google-api-python-client==1.6.2
-networkx==2.1
 numpy>=1.14.2
-pyasn1
-pyopenssl>=17.5.0
 pytest>=3.3.1
-scipy>=1.1.0
 task-queue>=0.4.1
-tenacity>=4.10.0
 -e git+https://github.com/seung-lab/tqdm.git#egg=tqdm
-oauth2client==3.0.0
-protobuf>=3.5.1
-python-jsonschema-objects==0.3.3
+oauth2client>=3.0.0


### PR DESCRIPTION
Reducing docker image size by
* only adding files to the Docker image that are actually required (no caches and eggs)
* removing build dependencies that are never used, or already installed
* removing requirements that are never imported in igneous itself
* collapsing the RUN layers to a single one (otherwise the cleanup is useless)
* removing libboost-dev after building the meshing library
* prevent pip from caching installation files
* removing some additional temporary/cached files from the installed site-packages

We could probably save quite some additional space if we switch to `python-slim` or even alpine... not sure how heavily others rely on the current images additional tools

Resolves #36 