### PR TITLE
feat: support for parallel upload for grid-regular tasks

### DIFF
--- a/igneous/task_creation.py
+++ b/igneous/task_creation.py
@@ -91,7 +91,7 @@ class FineIndexTaskIterator():
   def __iter__(self):
     for i in range(self.start, self.end):
       pt = self.to_coord(i)
-      offset = pt * self.shape
+      offset = pt * self.shape + self.bounds.minpt
       yield self.task(self.shape, offset)
 
     self.on_finish()

--- a/igneous/task_creation.py
+++ b/igneous/task_creation.py
@@ -88,15 +88,6 @@ class FinelyDividedTaskIterator():
     itr.start = max(self.start + slc.start, self.start)
     itr.end = min(self.start + slc.stop, self.end)
     return itr
-  
-  def to_coord(self, index):
-    """Convert an index into a grid coordinate defined by the task shape."""
-    sx, sy, sz = np.ceil(self.bounds.size3() / self.shape).astype(int)
-    sxy = sx * sy
-    z = index // sxy
-    y = (index - (z * sxy)) // sx
-    x = index - sx * (y + z * sy)
-    return Vec(x,y,z)
 
   def __iter__(self):
     for i in range(self.start, self.end):
@@ -105,6 +96,15 @@ class FinelyDividedTaskIterator():
       yield self.task(self.shape, offset)
 
     self.on_finish()
+
+  def to_coord(self, index):
+    """Convert an index into a grid coordinate defined by the task shape."""
+    sx, sy, sz = np.ceil(self.bounds.size3() / self.shape).astype(int)
+    sxy = sx * sy
+    z = index // sxy
+    y = (index - (z * sxy)) // sx
+    x = index - sx * (y + z * sy)
+    return Vec(x,y,z)
 
   def task(self, shape, offset):
     raise NotImplementedError()

--- a/igneous/task_creation.py
+++ b/igneous/task_creation.py
@@ -407,12 +407,15 @@ def create_downsampling_tasks(
 
     return DownsampleTaskIterator(bounds, shape)
 
-def create_deletion_tasks(layer_path, mip=0, num_mips=5):
+def create_deletion_tasks(layer_path, mip=0, num_mips=5, shape=None):
   vol = CloudVolume(layer_path)
   
-  shape = vol.mip_underlying(mip)[:3]
-  shape.x *= 2 ** num_mips
-  shape.y *= 2 ** num_mips
+  if shape is None:
+    shape = vol.mip_underlying(mip)[:3]
+    shape.x *= 2 ** num_mips
+    shape.y *= 2 ** num_mips
+  else:
+    shape = Vec(*shape)
 
   class DeleteTaskIterator(FinelyDividedTaskIterator):
     def task(self, shape, offset):

--- a/igneous/task_creation.py
+++ b/igneous/task_creation.py
@@ -442,7 +442,7 @@ def create_deletion_tasks(layer_path, mip=0, num_mips=5, shape=None):
       })
       vol.commit_provenance()
 
-  return DeleteTaskIterator(vol.bounds, shape)
+  return DeleteTaskIterator(vol.mip_bounds(mip), shape)
 
 def create_skeletonizing_tasks(
     cloudpath, mip, 
@@ -615,7 +615,7 @@ def create_meshing_tasks(
       }) 
       vol.commit_provenance()
 
-  return MeshTaskIterator(vol.bounds, shape)
+  return MeshTaskIterator(vol.mip_bounds(mip), shape)
 
 def create_transfer_tasks(
     src_layer_path, dest_layer_path, 
@@ -708,7 +708,7 @@ def create_transfer_tasks(
         vol.provenance.processing.append(job_details)
         vol.commit_provenance()
 
-  return TransferTaskIterator()
+  return TransferTaskIterator(bounds, shape)
 
 def create_contrast_normalization_tasks(
     src_path, dest_path, levels_path=None,
@@ -778,7 +778,7 @@ def create_contrast_normalization_tasks(
       }) 
       dvol.commit_provenance()
 
-  return ContrastNormalizationTaskIterator()
+  return ContrastNormalizationTaskIterator(bounds, shape)
 
 def create_luminance_levels_tasks(
     layer_path, levels_path=None, coverage_factor=0.01, 
@@ -896,7 +896,7 @@ def create_watershed_remap_tasks(
       }) 
       dvol.commit_provenance()
 
-  return WatershedRemapTaskIterator(bounds, shape)
+  return WatershedRemapTaskIterator(vol.bounds, shape)
 
 def compute_fixup_offsets(vol, points, shape):
   pts = map(np.array, points)
@@ -989,7 +989,7 @@ def create_quantize_tasks(
       }) 
       destvol.commit_provenance()
 
-  return QuantizeTasksIterator(destvol.bounds, shape)
+  return QuantizeTasksIterator(destvol.mip_bounds(mip), shape)
 
 # split the work up into ~1000 tasks (magnitude 3)
 def create_mesh_manifest_tasks(layer_path, magnitude=3):

--- a/igneous/task_creation.py
+++ b/igneous/task_creation.py
@@ -569,7 +569,7 @@ def create_skeleton_merge_tasks(
 def create_meshing_tasks(
     layer_path, mip, 
     shape=(256, 256, 256), max_simplification_error=40,
-    mesh_dir=None, cdn_cache=False 
+    mesh_dir=None, cdn_cache=False, dust_threshold=None
   ):
   shape = Vec(*shape)
 
@@ -592,6 +592,7 @@ def create_meshing_tasks(
         max_simplification_error=max_simplification_error,
         mesh_dir=mesh_dir, 
         cache_control=('' if cdn_cache else 'no-cache'),
+        dust_threshold=dust_threshold,
       )
 
     def on_finish(self):
@@ -604,13 +605,14 @@ def create_meshing_tasks(
           'max_simplification_error': max_simplification_error,
           'mesh_dir': mesh_dir,
           'cdn_cache': cdn_cache,
+          'dust_threshold': dust_threshold,
         },
         'by': OPERATOR_CONTACT,
         'date': strftime('%Y-%m-%d %H:%M %Z'),
       }) 
       vol.commit_provenance()
 
-  return MeshTaskIterator()
+  return MeshTaskIterator(vol.bounds, shape)
 
 def create_transfer_tasks(
     src_layer_path, dest_layer_path, 

--- a/igneous/task_creation.py
+++ b/igneous/task_creation.py
@@ -66,19 +66,29 @@ def get_bounds(vol, bounds, shape, mip, chunk_size=None):
 def num_tasks(bounds, shape):
   return int(reduce(operator.mul, np.ceil(bounds.size3() / shape)))
 
-class FineIndexTaskIterator():
+class FinelyDividedTaskIterator():
+  """
+  Parallelizes tasks that do not have overlap.
+
+  Evenly splits tasks between processes without 
+  regards to whether the dividing line lands in
+  the middle of a slice. 
+  """
   def __init__(self, bounds, shape):
     self.bounds = bounds 
     self.shape = Vec(*shape)
     self.start = 0
     self.end = num_tasks(bounds, shape)
+
   def __len__(self):
     return self.end - self.start
+  
   def __getitem__(self, slc):
     itr = copy.deepcopy(self)
     itr.start = max(self.start + slc.start, self.start)
     itr.end = min(self.start + slc.stop, self.end)
     return itr
+  
   def to_coord(self, index):
     """Convert an index into a grid coordinate defined by the task shape."""
     sx, sy, sz = np.ceil(self.bounds.size3() / self.shape).astype(int)
@@ -368,7 +378,7 @@ def create_downsampling_tasks(
 
     bounds = get_bounds(vol, bounds, shape, mip, vol.chunk_size)
     
-    class DownsampleTaskIterator(FineIndexTaskIterator):
+    class DownsampleTaskIterator(FinelyDividedTaskIterator):
       def task(self, shape, offset):
         return DownsampleTask(
           layer_path=layer_path,

--- a/igneous/tasks/skeletonization/tasks.py
+++ b/igneous/tasks/skeletonization/tasks.py
@@ -3,6 +3,7 @@ import six
 from functools import reduce
 import json
 import pickle
+import os
 import re
 from collections import defaultdict
 

--- a/igneous/tasks/tasks.py
+++ b/igneous/tasks/tasks.py
@@ -175,6 +175,9 @@ class BlackoutTask(RegisteredTask):
       cloudpath, mip, shape, 
       offset, value, non_aligned_writes
     )
+    self.shape = Vec(*self.shape)
+    self.offset = Vec(*self.offset)
+
   def execute(self):
     vol = CloudVolume(self.cloudpath, self.mip, non_aligned_writes=self.non_aligned_writes)
     bounds = Bbox(self.offset, self.shape + self.offset)

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -324,7 +324,7 @@ def test_quantize():
 
     info = create_quantized_affinity_info(
         storage.layer_path, qpath, shape, 
-        mip=0, chunk_size=[64,64,64]
+        mip=0, chunk_size=[64,64,64], encoding='raw'
     )
     qcv = CloudVolume(qpath, info=info)
     qcv.commit_info()


### PR DESCRIPTION
This enables the following motif:

```python
import gevent.monkey
gevent.monkey.patch_all(thread=False)

import numpy as np
from cloudvolume import *
from taskqueue import GreenTaskQueue, MockTaskQueue, LocalTaskQueue

import igneous.task_creation as tc

def downsample():
  cloudpath = '...'

  return tc.create_downsampling_tasks(
    cloudpath, 
    mip=0, 
    num_mips=5, 
    fill_missing=True,
  )

tasks = downsample()
tq = GreenTaskQueue('igneous-queue')
tq.insert_all(tasks, parallel=8)
```