### PR TITLE
perf: meshing with rounds

### DIFF
--- a/igneous/task_creation.py
+++ b/igneous/task_creation.py
@@ -582,7 +582,8 @@ def create_skeleton_merge_tasks(
 def create_meshing_tasks(
     layer_path, mip, 
     shape=(256, 256, 256), max_simplification_error=40,
-    mesh_dir=None, cdn_cache=False, dust_threshold=None
+    mesh_dir=None, cdn_cache=False, dust_threshold=None,
+    rounds=1
   ):
   shape = Vec(*shape)
 
@@ -605,7 +606,8 @@ def create_meshing_tasks(
         max_simplification_error=max_simplification_error,
         mesh_dir=mesh_dir, 
         cache_control=('' if cdn_cache else 'no-cache'),
-        dust_threshold=dust_threshold,
+        dust_threshold=int(dust_threshold),
+        rounds=int(rounds),
       )
 
     def on_finish(self):

--- a/igneous/task_creation.py
+++ b/igneous/task_creation.py
@@ -583,7 +583,7 @@ def create_meshing_tasks(
     layer_path, mip, 
     shape=(256, 256, 256), max_simplification_error=40,
     mesh_dir=None, cdn_cache=False, dust_threshold=None,
-    rounds=1
+    rounds=1, progress=False
   ):
   shape = Vec(*shape)
 
@@ -608,6 +608,7 @@ def create_meshing_tasks(
         cache_control=('' if cdn_cache else 'no-cache'),
         dust_threshold=int(dust_threshold),
         rounds=int(rounds),
+        progress=bool(progress),
       )
 
     def on_finish(self):

--- a/igneous/tasks/tasks.py
+++ b/igneous/tasks/tasks.py
@@ -355,6 +355,8 @@ class MeshTask(RegisteredTask):
     iterator = enumerate(scatter(segids, rounds))
     pbariter = tqdm(iterator, disable=(not self.progress), desc="Round", total=rounds)
 
+    segids = set(segids)
+
     round_data = None
     for i, segid_subset in pbariter:
       del round_data
@@ -365,7 +367,8 @@ class MeshTask(RegisteredTask):
       else:
         round_data = data
 
-      round_data = fastremap.mask(round_data, segid_subset, in_place=True) 
+      segidmask = segids - set(segid_subset)
+      round_data = fastremap.mask(round_data, segidmask, in_place=True) 
       self._compute_meshes(round_data)
 
   def _compute_meshes(self, data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=6.7
 cloud-volume>=0.47.2
-fastremap>=1.5.1
+fastremap>=1.5.2
 google-cloud-logging
 kimimaro
 networkx==2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=6.7
 cloud-volume>=0.47.2
-fastremap>=1.5.0
+fastremap>=1.5.1
 google-cloud-logging
 kimimaro
 networkx==2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click>=6.7
 cloud-volume>=0.47.2
+fastremap>=1.5.0
 google-cloud-logging
 kimimaro
 networkx==2.1


### PR DESCRIPTION
The initial meshing operation stores high resolution meshes in an expensive representation. The idea here is to only store about half of them at a time by masking half the labels and meshing, then masking the other half and meshing.

The masking operation takes a long time (1-2 min) but uses next to no memory. Will post a graph soon.