### PR TITLE
feat: shard downsampling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,15 @@
 CHANGES
 =======
 
+0.5.0
+-----
+
+* release(0.5.0): Adds --sharded to xfer task
+* chore: remove unused environment variables
+* docs: info on sharded scripting and delete CLI
+* chore: delete obsolete dockerfile
+* feat: create image shards (#105)
+
 0.4.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -239,9 +239,10 @@ Here we show an example where we insert the tasks to downsample 4 mip levels usi
 PATH=gs://mydataset/layer 
 QUEUE=fq://./my-queue # could also be sqs://
 
-igneous downsample $PATH --mip 0 --num-mips 4 --queue $QUEUE # downsample
+igneous downsample $PATH --mip 0 --num-mips 4 --queue $QUEUE # downsample 2x2x1
 igneous execute $QUEUE # process the queue
-igneous downsample $PATH --mip 4 --num-mips 3 --volumetric --sparse --queue $QUEUE # superdownsample
+igneous downsample $PATH --mip 4 --num-mips 3 --volumetric --sparse --queue $QUEUE # superdownsample w/ 2x2x2 sparse
+igneous downsample $PATH --mip 0 --queue $QUEUE --sharded # sharded downsample
 igneous execute $QUEUE # process the queue
 ```
 
@@ -264,6 +265,15 @@ tasks = create_downsampling_tasks(
     compress='gzip', # None, 'gzip', and 'br' (brotli) are options
     factor=(2,2,1), # common options are (2,2,1) and (2,2,2)
   )
+
+# for sharded downsample (only 1 mip at a time)
+tasks = create_image_shard_downsample_tasks(
+  cloudpath, mip=0, fill_missing=False, 
+  sparse=False, chunk_size=None,
+  encoding=None, memory_target=MEMORY_TARGET,
+  agglomerate=False, timestamp=None,
+  factor=(2,2,1)
+)
 ```
 
 | Variable             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |

--- a/igneous/downsample_scales.py
+++ b/igneous/downsample_scales.py
@@ -216,13 +216,35 @@ def create_downsample_scales(
   else:
     chunk_size = [ chunk_size ]
 
+  for i in range(mip + 1, mip + len(scales) + 1):
+    vol.scales[i]['chunk_sizes'] = chunk_size
+
+  vol.commit_info()
+  return vol
+
+def add_scale(
+  layer_path, mip,
+  preserve_chunk_size=True, chunk_size=None,
+  encoding=None, factor=None
+):
+  vol = CloudVolume(layer_path, mip=mip)
+
+  vol.meta.add_scale((2,2,1), encoding=encoding, chunk_size=chunk_size)
+
+  if chunk_size is None:
+    if preserve_chunk_size or len(scales) == 0:
+      chunk_size = vol.scales[mip]['chunk_sizes']
+    else:
+      chunk_size = vol.scales[mip + 1]['chunk_sizes']
+  else:
+    chunk_size = [ chunk_size ]
+
   if encoding is None:
     encoding = vol.scales[mip]['encoding']
 
   for i in range(mip + 1, mip + len(scales) + 1):
     vol.scales[i]['chunk_sizes'] = chunk_size
 
-  vol.commit_info()
   return vol
 
 

--- a/igneous/downsample_scales.py
+++ b/igneous/downsample_scales.py
@@ -200,23 +200,23 @@ def create_downsample_scales(
   ):
   vol = CloudVolume(layer_path, mip)
 
-  scales = compute_scales(vol, mip, ds_shape, axis, factor, chunk_size)
+  resolutions = compute_scales(vol, mip, ds_shape, axis, factor, chunk_size)
 
-  if len(scales) == 0:
+  if len(resolutions) == 0:
     print("WARNING: No scales generated.")
 
-  for scale in scales:
-    vol.meta.add_resolution(scale, encoding=encoding, chunk_size=chunk_size)
+  for res in resolutions:
+    vol.meta.add_resolution(res, encoding=encoding, chunk_size=chunk_size)
 
   if chunk_size is None:
-    if preserve_chunk_size or len(scales) == 0:
+    if preserve_chunk_size or len(resolutions) == 0:
       chunk_size = vol.scales[mip]['chunk_sizes']
     else:
       chunk_size = vol.scales[mip + 1]['chunk_sizes']
   else:
     chunk_size = [ chunk_size ]
 
-  for i in range(mip + 1, mip + len(scales) + 1):
+  for i in range(mip + 1, mip + len(resolutions) + 1):
     vol.scales[i]['chunk_sizes'] = chunk_size
 
   vol.commit_info()
@@ -238,7 +238,7 @@ def add_scale(
   )
 
   if chunk_size is None:
-    if preserve_chunk_size or len(scales) == 0:
+    if preserve_chunk_size:
       chunk_size = vol.scales[mip]['chunk_sizes']
     else:
       chunk_size = vol.scales[mip + 1]['chunk_sizes']
@@ -248,8 +248,7 @@ def add_scale(
   if encoding is None:
     encoding = vol.scales[mip]['encoding']
 
-  for i in range(mip + 1, mip + len(scales) + 1):
-    vol.scales[i]['chunk_sizes'] = chunk_size
+  vol.scales[mip + 1]['chunk_sizes'] = chunk_size
 
   return vol
 

--- a/igneous/downsample_scales.py
+++ b/igneous/downsample_scales.py
@@ -229,7 +229,13 @@ def add_scale(
 ):
   vol = CloudVolume(layer_path, mip=mip)
 
-  vol.meta.add_scale((2,2,1), encoding=encoding, chunk_size=chunk_size)
+  if factor is None:
+    factor = (2,2,1)
+
+  new_resolution = vol.resolution * Vec(*factor)
+  vol.meta.add_resolution(
+    new_resolution, encoding=encoding, chunk_size=chunk_size
+  )
 
   if chunk_size is None:
     if preserve_chunk_size or len(scales) == 0:
@@ -246,7 +252,6 @@ def add_scale(
     vol.scales[i]['chunk_sizes'] = chunk_size
 
   return vol
-
 
 def downsample_shape_from_memory_target(
   data_width, cx, cy, cz, 

--- a/igneous/shards.py
+++ b/igneous/shards.py
@@ -27,10 +27,13 @@ def image_shard_shape_from_spec(
     shape = Vec(0,0,0, dtype=np.uint64)
 
     i = 0
+    over = [ False, False, False ]
     while i < preshift_bits:
       changed = False
       for dim in range(3):
-        if 2 ** (shape[dim] + 1) <= grid_size[dim]:
+        if 2 ** (shape[dim] + 1) < grid_size[dim] * 2 and not over[dim]:
+          if 2 ** (shape[dim] + 1) >= grid_size[dim]:
+            over[dim] = True
           shape[dim] += one
           i += 1
           changed = True

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -482,6 +482,17 @@ def create_image_shard_transfer_tasks(
 
   return ImageShardTransferTaskIterator(bounds, shape)
 
+def create_image_shard_downsample_tasks(
+  cloudpath, mip=0, fill_missing=False, 
+  num_mips=5, 
+  sparse=False, chunk_size=None,
+  encoding=None, delete_black_uploads=False, 
+  background_color=0, compress=None,
+  factor=None
+):
+  pass
+
+
 def create_deletion_tasks(
     layer_path, mip=0, num_mips=5, 
     shape=None, bounds=None

--- a/igneous/tasks/__init__.py
+++ b/igneous/tasks/__init__.py
@@ -6,5 +6,5 @@ from .image import (
   TransferTask, WatershedRemapTask, DeleteTask, 
   LuminanceLevelsTask, ContrastNormalizationTask,
   MaskAffinitymapTask, InferenceTask, BlackoutTask,
-  TouchTask, ImageShardTransferTask
+  TouchTask, ImageShardTransferTask, ImageShardDownsampleTask
 )

--- a/igneous/tasks/image.py
+++ b/igneous/tasks/image.py
@@ -546,6 +546,12 @@ def ImageShardDownsampleTask(
   agglomerate: bool = False,
   timestamp: Optional[int] = None,
 ):
+  """
+  Generate a single downsample level for a shard.
+  Shards are usually hundreds of megabytes to several
+  gigabyte of data, so it is usually unrealistic from a
+  memory perspective to make more than one mip at a time.
+  """
   shape = Vec(*shape)
   offset = Vec(*offset)
   mip = int(mip)
@@ -591,7 +597,7 @@ def ImageShardDownsampleTask(
   (filename, shard) = src_vol.image.make_shard(
     output_img, (bbox // 2), (mip + 1), progress=False
   )
-  basepath = dst_vol.meta.join(
-    dst_vol.cloudpath, dst_vol.meta.key(mip + 1)
+  basepath = src_vol.meta.join(
+    src_vol.cloudpath, src_vol.meta.key(mip + 1)
   )
   CloudFiles(basepath).put(filename, shard)

--- a/igneous/tasks/image.py
+++ b/igneous/tasks/image.py
@@ -560,7 +560,7 @@ def ImageShardDownsampleTask(
 
   src_vol = CloudVolume(
     src_path, fill_missing=fill_missing, 
-    mip=mip, bounded=False, progress=True
+    mip=mip, bounded=False, progress=False
   )
   chunk_size = src_vol.meta.chunk_size(mip)
 

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -112,7 +112,11 @@ def downsample(
   """
   if cseg and compresso:
     print("igneous: must choose one of --cseg or --compresso")
-    sys.exit()
+    return
+
+  if sharded and num_mips != 1:
+    print("igneous: sharded downsamples only support producing one mip at a time.")
+    return
 
   encoding = None
   if cseg:

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -87,12 +87,14 @@ def license():
 @click.option('--volumetric', is_flag=True, default=False, help="Use 2x2x2 downsampling.")
 @click.option('--delete-bg', is_flag=True, default=False, help="Issue a delete instead of uploading a background tile. This is helpful on systems that don't like tiny files.")
 @click.option('--bg-color', default=0, help="Determines which color is regarded as background. Default: 0")
+@click.option('--sharded', is_flag=True, default=False, help="Generate sharded downsamples which reduces the number of files.")
+@click.option('--memory', default=3.5e9, type=int, help="(sharded only) Task memory limit in bytes. Task shape will be chosen to fit and maximize downsamples.", show_default=True)
 @click.pass_context
 def downsample(
 	ctx, path, queue, mip, fill_missing, 
 	num_mips, cseg, compresso, sparse, 
 	chunk_size, compress, volumetric,
-	delete_bg, bg_color
+	delete_bg, bg_color, sharded, memory
 ):
   """
   Create an image pyramid for grayscale or labeled images.
@@ -122,15 +124,23 @@ def downsample(
   if volumetric:
   	factor = (2,2,2)
 
-  tasks = tc.create_downsampling_tasks(
-    path, mip=mip, fill_missing=fill_missing, 
-    num_mips=num_mips, sparse=sparse, 
-    chunk_size=chunk_size, encoding=encoding, 
-    delete_black_uploads=delete_bg, 
-    background_color=bg_color, 
-    compress=compress,
-    factor=factor  	
-  )
+  if sharded:
+    tasks = tc.create_image_shard_downsample_tasks(
+      path, mip=mip, fill_missing=fill_missing, 
+      sparse=sparse, chunk_size=chunk_size,
+      encoding=encoding, memory_target=memory,
+      factor=factor,
+    )
+  else:
+    tasks = tc.create_downsampling_tasks(
+      path, mip=mip, fill_missing=fill_missing, 
+      num_mips=num_mips, sparse=sparse, 
+      chunk_size=chunk_size, encoding=encoding, 
+      delete_black_uploads=delete_bg, 
+      background_color=bg_color, 
+      compress=compress,
+      factor=factor  	
+    )
 
   parallel = int(ctx.obj.get("parallel", 1))
   tq = TaskQueue(normalize_path(queue))

--- a/test/test_shards.py
+++ b/test/test_shards.py
@@ -1,0 +1,66 @@
+import pytest
+import operator
+from functools import reduce
+
+import numpy as np
+from cloudvolume import CloudVolume, Bbox, Vec
+import cloudvolume.lib as lib
+from cloudvolume.datasource.precomputed.image.common import (
+  gridpoints, compressed_morton_code
+)
+from cloudvolume.datasource.precomputed.sharding import ShardReader, ShardingSpecification
+
+from igneous.task_creation.image import create_sharded_image_info
+from igneous.shards import image_shard_shape_from_spec
+
+def test_sharded_image_bits():
+  def test_scale(scale):
+    dataset_size = Vec(*scale["size"])
+    chunk_size = Vec(*scale["chunk_sizes"][0])
+
+    spec = create_sharded_image_info( 
+      dataset_size=dataset_size,
+      chunk_size=chunk_size,
+      encoding="jpeg",
+      dtype=np.uint8
+    )
+
+    shape = image_shard_shape_from_spec(
+      spec, dataset_size, chunk_size
+    )
+    shape = lib.min2(shape, dataset_size)
+    bbox = Bbox.from_vec(shape)
+    dataset_bbox = Bbox.from_vec(dataset_size)
+    gpts = list(gridpoints(bbox, dataset_bbox, chunk_size))
+    grid_size = np.ceil(dataset_size / chunk_size).astype(np.int64)
+
+    spec = ShardingSpecification.from_dict(spec)
+    reader = ShardReader(None, None, spec)
+
+    morton_codes = compressed_morton_code(gpts, grid_size)
+    all_same_shard = bool(reduce(lambda a,b: operator.eq(a,b) and a,
+      map(reader.get_filename, morton_codes)
+    ))
+
+    assert all_same_shard
+
+  test_scale({
+    'chunk_sizes': [[128, 128, 64]],
+    'encoding': 'jpeg',
+    'key': '48_48_30',
+    'resolution': [48, 48, 30],
+    'size': [1536, 1408, 2046],
+    'voxel_offset': [0, 0, 0]
+  })
+
+  test_scale({
+    'chunk_sizes': [[128, 128, 64]],
+    'encoding': 'jpeg',
+    'key': '24_24_30',
+    'resolution': [24, 24, 30],
+    'size': [3072, 2816, 2046],
+    'voxel_offset': [0, 0, 0]
+  })
+
+
+


### PR DESCRIPTION
This feature adds sharded downsampling to Igneous. A highlight is that all sharding calculations are done completely automatically and it is as simple to use as:

```bash
igneous downsample $PATH --queue $QUEUE --sharded --mip 0
```

The default parameters pick shard constructions that easily fit into the memory of commodity hardware, making it simple to deploy.

A downside is that this constraint means only a single downsample level can be computed per run. In the future, it may be desirable to add additional downsample levels, but it will radically increase the amount of memory required. For the following reason:

```
Needed in memory:
1 mip: 1 shard
2 mips: 5 shards
3 mips: 21 shards
```

Perhaps it is possible to construct each shard in a more online fashion, but it seems tricky.

Another artifact of this one-by-one approach is we reaquire the integer truncation problem. 





