### PR TITLE
feat: sharded meshes (single res using trivial multi-res)

### DIFF
--- a/igneous/task_creation/common.py
+++ b/igneous/task_creation/common.py
@@ -136,3 +136,67 @@ def graphene_prefixes(
       prefixes.add(num)
 
   return prefixes
+
+def compute_shard_params_for_hashed(
+  num_labels, shard_index_bytes=2**13, minishard_index_bytes=2**15
+):
+  """
+  Computes the shard parameters for objects that
+  have been randomly hashed (e.g. murmurhash) so
+  that the keys are evenly distributed. This is
+  applicable to skeletons and meshes.
+
+  The equations come from the following assumptions.
+  a. The keys are approximately uniformly randomly distributed.
+  b. Preshift bits aren't useful for random keys so are zero.
+  c. Our goal is to optimize the size of the shard index and
+    the minishard indices to be reasonably sized. The default
+    values are set for a 100 Mbps connection.
+  d. The equations below come from finding a solution to 
+    these equations given the constraints provided.
+
+      num_shards * num_minishards_per_shard 
+        = 2^(shard_bits) * 2^(minishard_bits) 
+        = num_labels_in_dataset / labels_per_minishard
+
+      # from defininition of minishard_bits assuming fixed capacity
+      labels_per_minishard = minishard_index_bytes / 3 / 8
+
+      # from definition of minishard bits
+      minishard_bits = ceil(log2(shard_index_bytes / 2 / 8)) 
+
+  Returns: (shard_bits, minishard_bits, preshift_bits)
+  """
+  if num_labels <= 0:
+    return (0,0,0)
+
+  num_minishards_per_shard = shard_index_bytes / 2 / 8
+  labels_per_minishard = minishard_index_bytes / 3 / 8
+  labels_per_shard = num_minishards_per_shard * labels_per_minishard
+
+  if num_labels >= labels_per_shard:
+    minishard_bits = np.ceil(np.log2(num_minishards_per_shard))
+    shard_bits = np.ceil(np.log2(
+      num_labels / (labels_per_minishard * (2 ** minishard_bits))
+    ))
+  elif num_labels >= labels_per_minishard:
+    minishard_bits = np.ceil(np.log2(
+      num_labels / labels_per_minishard
+    ))
+    shard_bits = 0
+  else:
+    minishard_bits = 0
+    shard_bits = 0
+
+  capacity = labels_per_shard * (2 ** shard_bits)
+  utilized_capacity = num_labels / capacity
+
+  # Try to pack shards to capacity, allow going
+  # about 10% over the input level.
+  if utilized_capacity <= 0.55:
+    shard_bits -= 1
+
+  minishard_bits = max(minishard_bits, 0)
+  shard_bits = max(shard_bits, 0)
+
+  return (int(shard_bits), int(minishard_bits), 0)

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -392,7 +392,7 @@ def create_sharded_multires_mesh_tasks(
   minishard_index_encoding='gzip', 
   data_encoding='gzip',
   mesh_dir:Optional[str] = None, 
-  sql_db:Optional[str] = None
+  spatial_index_db:Optional[str] = None
 ) -> Iterator[MultiResShardedMeshMergeTask]: 
 
   configure_multires_info(
@@ -416,7 +416,7 @@ def create_sharded_multires_mesh_tasks(
   cv.mesh.meta.commit_info()
 
   # rebuild b/c sharding changes the mesh source class
-  cv = CloudVolume(cloudpath, progress=True) 
+  cv = CloudVolume(cloudpath, progress=True, spatial_index_db=spatial_index_db) 
   cv.mip = cv.mesh.meta.mip
 
   # 17 sec to download for pinky100

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -18,7 +18,8 @@ from cloudfiles import CloudFiles
 
 from igneous.tasks import (
   MeshTask, MeshManifestTask, GrapheneMeshTask,
-  MeshSpatialIndex, MultiResUnshardedMeshMergeTask
+  MeshSpatialIndex, MultiResShardedMeshMergeTask,
+  MultiResUnshardedMeshMergeTask
 )
 from .common import (
   operator_contact, FinelyDividedTaskIterator, 
@@ -383,15 +384,15 @@ def create_unsharded_multires_mesh_tasks(
   return UnshardedMultiResTaskIterator()
 
 def create_sharded_multires_mesh_tasks(
-    cloudpath:str, mip:int, 
-    preshift_bits:int, minishard_bits:int, shard_bits:int,
-    num_lod:int = 1, 
-    vertex_quantization_bits:int = 16,
-    minishard_index_encoding='gzip', 
-    data_encoding='gzip',
-    mesh_dir:Optional[str] = None, 
-    sql_db:Optional[str] = None
-  ): 
+  cloudpath:str, mip:int, 
+  preshift_bits:int, minishard_bits:int, shard_bits:int,
+  num_lod:int = 1, 
+  vertex_quantization_bits:int = 16,
+  minishard_index_encoding='gzip', 
+  data_encoding='gzip',
+  mesh_dir:Optional[str] = None, 
+  sql_db:Optional[str] = None
+) -> Iterator[MultiResShardedMeshMergeTask]: 
 
   configure_multires_info(
     cloudpath, mip, 
@@ -452,7 +453,7 @@ def create_sharded_multires_mesh_tasks(
   }) 
   cv.commit_provenance()
 
-  return (
+  return [
     ShardedMultiResMeshMergeTask(
       cloudpath, shard_no, 
       num_lod=num_lod,
@@ -460,4 +461,4 @@ def create_sharded_multires_mesh_tasks(
       sql_db=sql_db,
     )
     for shard_no in shard_labels.keys()
-  )
+  ]

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -436,7 +436,7 @@ def create_sharded_multires_mesh_tasks(
 
   cv = CloudVolume(cloudpath)
 
-  # perf: ~36k hashes/sec
+  # perf: ~66.5k hashes/sec on M1 ARM64
   shardfn = lambda lbl: cv.mesh.reader.spec.compute_shard_location(lbl).shard_number
 
   shard_labels = defaultdict(list)

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -439,6 +439,14 @@ def compute_shard_params_for_hashed(
     minishard_bits = 0
     shard_bits = 0
 
+  capacity = labels_per_shard * (2 ** shard_bits)
+  utilized_capacity = num_labels / capacity
+
+  # Try to pack shards to capacity, allow going
+  # about 10% over the input level.
+  if utilized_capacity <= 0.55:
+    shard_bits -= 1
+
   minishard_bits = max(minishard_bits, 0)
   shard_bits = max(shard_bits, 0)
 

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -394,8 +394,7 @@ def create_sharded_multires_mesh_tasks(
   num_lod:int = 1, 
   draco_compression_level:int = 1,
   vertex_quantization_bits:int = 16,
-  minishard_index_encoding='gzip', 
-  data_encoding='gzip',
+  minishard_index_encoding="gzip", 
   mesh_dir:Optional[str] = None, 
   spatial_index_db:Optional[str] = None
 ) -> Iterator[MultiResShardedMeshMergeTask]: 
@@ -413,7 +412,7 @@ def create_sharded_multires_mesh_tasks(
     minishard_bits=minishard_bits,
     shard_bits=shard_bits,
     minishard_index_encoding=minishard_index_encoding,
-    data_encoding=data_encoding,
+    data_encoding="raw", # draco encoded meshes
   )
 
   cv = CloudVolume(cloudpath)

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -418,6 +418,9 @@ def compute_shard_params_for_hashed(
 
   Returns: (shard_bits, minishard_bits, preshift_bits)
   """
+  if num_labels <= 0:
+    return (0,0,0)
+
   num_minishards_per_shard = shard_index_bytes / 2 / 8
   labels_per_minishard = minishard_index_bytes / 3 / 8
   labels_per_shard = num_minishards_per_shard * labels_per_minishard

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -26,7 +26,8 @@ from igneous.tasks import (
 )
 from .common import (
   operator_contact, FinelyDividedTaskIterator, 
-  get_bounds, num_tasks, graphene_prefixes
+  get_bounds, num_tasks, graphene_prefixes,
+  compute_shard_params_for_hashed
 )
 
 __all__ = [
@@ -387,70 +388,6 @@ def create_unsharded_multires_mesh_tasks(
         )
 
   return UnshardedMultiResTaskIterator()
-
-def compute_shard_params_for_hashed(
-  num_labels, shard_index_bytes=2**13, minishard_index_bytes=2**15
-):
-  """
-  Computes the shard parameters for objects that
-  have been randomly hashed (e.g. murmurhash) so
-  that the keys are evenly distributed. This is
-  applicable to skeletons and meshes.
-
-  The equations come from the following assumptions.
-  a. The keys are approximately uniformly randomly distributed.
-  b. Preshift bits aren't useful for random keys so are zero.
-  c. Our goal is to optimize the size of the shard index and
-    the minishard indices to be reasonably sized. The default
-    values are set for a 100 Mbps connection.
-  d. The equations below come from finding a solution to 
-    these equations given the constraints provided.
-
-      num_shards * num_minishards_per_shard 
-        = 2^(shard_bits) * 2^(minishard_bits) 
-        = num_labels_in_dataset / labels_per_minishard
-
-      # from defininition of minishard_bits assuming fixed capacity
-      labels_per_minishard = minishard_index_bytes / 3 / 8
-
-      # from definition of minishard bits
-      minishard_bits = ceil(log2(shard_index_bytes / 2 / 8)) 
-
-  Returns: (shard_bits, minishard_bits, preshift_bits)
-  """
-  if num_labels <= 0:
-    return (0,0,0)
-
-  num_minishards_per_shard = shard_index_bytes / 2 / 8
-  labels_per_minishard = minishard_index_bytes / 3 / 8
-  labels_per_shard = num_minishards_per_shard * labels_per_minishard
-
-  if num_labels >= labels_per_shard:
-    minishard_bits = np.ceil(np.log2(num_minishards_per_shard))
-    shard_bits = np.ceil(np.log2(
-      num_labels / (labels_per_minishard * (2 ** minishard_bits))
-    ))
-  elif num_labels >= labels_per_minishard:
-    minishard_bits = np.ceil(np.log2(
-      num_labels / labels_per_minishard
-    ))
-    shard_bits = 0
-  else:
-    minishard_bits = 0
-    shard_bits = 0
-
-  capacity = labels_per_shard * (2 ** shard_bits)
-  utilized_capacity = num_labels / capacity
-
-  # Try to pack shards to capacity, allow going
-  # about 10% over the input level.
-  if utilized_capacity <= 0.55:
-    shard_bits -= 1
-
-  minishard_bits = max(minishard_bits, 0)
-  shard_bits = max(shard_bits, 0)
-
-  return (int(shard_bits), int(minishard_bits), 0)
 
 def create_sharded_multires_mesh_tasks(
   cloudpath:str, 

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -299,8 +299,9 @@ def create_spatial_index_mesh_tasks(
   return SpatialIndexMeshTaskIterator(vol.bounds, shape)
 
 def configure_multires_info(
-  cloudpath:str, mip:int, 
-  vertex_quantization_bits:int, mesh_dir:str
+  cloudpath:str,
+  vertex_quantization_bits:int, 
+  mesh_dir:str
 ):
   """
   Computes properties and uploads a multires 
@@ -310,8 +311,7 @@ def configure_multires_info(
 
   vol = CloudVolume(cloudpath, mip=mip)
 
-  if mesh_dir is None:
-    mesh_dir = f"mesh_mip_{mip}_err_40"
+  mesh_dir = mesh_dir or vol.info.get("mesh", None)
 
   if not "mesh" in vol.info:
     vol.info['mesh'] = mesh_dir
@@ -339,7 +339,7 @@ def configure_multires_info(
     )
 
 def create_unsharded_multires_mesh_tasks(
-  cloudpath:str, mip:int, num_lod:int = 1, 
+  cloudpath:str, num_lod:int = 1, 
   magnitude:int = 3, mesh_dir:str = None,
   vertex_quantization_bits:int = 16
 ) -> Iterator:
@@ -351,8 +351,9 @@ def create_unsharded_multires_mesh_tasks(
   assert int(magnitude) == magnitude
 
   configure_multires_info(
-    cloudpath, mip, 
-    vertex_quantization_bits, mesh_dir
+    cloudpath, 
+    vertex_quantization_bits, 
+    mesh_dir
   )
 
   vol = CloudVolume(cloudpath, mip=mip)
@@ -384,7 +385,7 @@ def create_unsharded_multires_mesh_tasks(
   return UnshardedMultiResTaskIterator()
 
 def create_sharded_multires_mesh_tasks(
-  cloudpath:str, mip:int, 
+  cloudpath:str, 
   preshift_bits:int, minishard_bits:int, shard_bits:int,
   num_lod:int = 1, 
   vertex_quantization_bits:int = 16,
@@ -395,8 +396,9 @@ def create_sharded_multires_mesh_tasks(
 ) -> Iterator[MultiResShardedMeshMergeTask]: 
 
   configure_multires_info(
-    cloudpath, mip, 
-    vertex_quantization_bits, mesh_dir
+    cloudpath, 
+    vertex_quantization_bits, 
+    mesh_dir
   )
 
   spec = ShardingSpecification(

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -418,13 +418,24 @@ def compute_shard_params_for_hashed(
 
   Returns: (shard_bits, minishard_bits, preshift_bits)
   """
+  num_minishards_per_shard = shard_index_bytes / 2 / 8
   labels_per_minishard = minishard_index_bytes / 3 / 8
-  minishard_bits = np.ceil(np.log2(
-    shard_index_bytes / 2 / 8
-  ))
-  shard_bits = np.ceil(np.log2(
-    num_labels / (labels_per_minishard * (2 ** minishard_bits))
-  ))
+  labels_per_shard = num_minishards_per_shard * labels_per_minishard
+
+  if num_labels >= labels_per_shard:
+    minishard_bits = np.ceil(np.log2(num_minishards_per_shard))
+    shard_bits = np.ceil(np.log2(
+      num_labels / (labels_per_minishard * (2 ** minishard_bits))
+    ))
+  elif num_labels >= labels_per_minishard:
+    minishard_bits = np.ceil(np.log2(
+      num_labels / labels_per_minishard
+    ))
+    shard_bits = 0
+  else:
+    minishard_bits = 0
+    shard_bits = 0
+
   minishard_bits = max(minishard_bits, 0)
   shard_bits = max(shard_bits, 0)
 

--- a/igneous/task_creation/skeleton.py
+++ b/igneous/task_creation/skeleton.py
@@ -269,7 +269,7 @@ def create_sharded_skeleton_merge_tasks(
     layer_path, dust_threshold, tick_threshold,
     preshift_bits, minishard_bits, shard_bits,
     minishard_index_encoding='gzip', data_encoding='gzip',
-    max_cable_length=None
+    max_cable_length=None, spatial_index_db=None
   ): 
   spec = ShardingSpecification(
     type='neuroglancer_uint64_sharded_v1',
@@ -285,7 +285,8 @@ def create_sharded_skeleton_merge_tasks(
   cv.skeleton.meta.info['sharding'] = spec.to_dict()
   cv.skeleton.meta.commit_info()
 
-  cv = CloudVolume(layer_path, progress=True) # rebuild b/c sharding changes the skeleton object
+  # rebuild b/c sharding changes the skeleton object
+  cv = CloudVolume(layer_path, progress=True, spatial_index_db=spatial_index_db) 
   cv.mip = cv.skeleton.meta.mip
 
   # 17 sec to download for pinky100

--- a/igneous/tasks/__init__.py
+++ b/igneous/tasks/__init__.py
@@ -6,6 +6,7 @@ from .mesh import (
   MeshTask, MeshManifestTask, 
   GrapheneMeshTask, MeshSpatialIndex,
   MultiResUnshardedMeshMergeTask,
+  MultiResShardedMeshMergeTask,
 )
 from .image import (
   HyperSquareConsensusTask, #HyperSquareTask,

--- a/igneous/tasks/mesh/mesh.py
+++ b/igneous/tasks/mesh/mesh.py
@@ -243,10 +243,7 @@ class MeshTask(RegisteredTask):
   def _upload_batch(self, meshes, bbox):
     cf = CloudFiles(self.layer_path, progress=self.options['progress'])
 
-    mbuf = MapBuffer(
-      meshes, compress="br", 
-      tobytesfn=lambda mesh: mesh.to_precomputed()
-    )
+    mbuf = MapBuffer(meshes, compress="br")
 
     cf.put(
       f"{self._mesh_dir}/{bbox.to_filename()}.frags",

--- a/igneous/tasks/mesh/mesh.py
+++ b/igneous/tasks/mesh/mesh.py
@@ -305,8 +305,8 @@ class MeshTask(RegisteredTask):
     )
 
     if self.options['encoding'] == 'draco':
-      mesh_binary = DracoPy.encode_mesh_to_buffer(
-        mesh.vertices.flatten('C'), mesh.faces.flatten('C'), 
+      mesh_binary = DracoPy.encode(
+        mesh.vertices, mesh.faces, 
         **self.draco_encoding_settings
       )
     elif self.options['encoding'] == 'precomputed':
@@ -476,8 +476,8 @@ class GrapheneMeshTask(RegisteredTask):
     self.mesher.erase(obj_id)
     mesh.vertices[:] += self.bounds.minpt * self.cv.resolution
 
-    mesh_binary = DracoPy.encode_mesh_to_buffer(
-      mesh.vertices.flatten('C'), mesh.faces.flatten('C'), 
+    mesh_binary = DracoPy.encode(
+      mesh.vertices, mesh.faces, 
       **self.draco_encoding_settings
     )
 

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -102,12 +102,15 @@ def process_mesh(
     frag=0
   )
 
+  quantization_range = np.max(mesh.vertices, axis=0) - np.min(mesh.vertices, axis=0)
+  quantization_range = np.max(quantization_range)
+
   mesh = DracoPy.encode_mesh_to_buffer(
     mesh.vertices.flatten('C'), mesh.faces.flatten('C'), 
     quantization_bits=vqb,
     compression_level=draco_compression_level,
-    quantization_range=np.max(mesh.vertices),
-    quantization_origin=[0,0,0],
+    quantization_range=quantization_range,
+    quantization_origin=np.min(mesh.vertices, axis=0),
     create_metadata=True,
   )
   manifest.fragment_offsets = [ len(mesh) ]

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -177,7 +177,7 @@ def MultiResShardedMeshMergeTask(
     for label, mesh_frags in tqdm(meshes.items(), disable=(not progress))
   }
   data_offset = { 
-    label: len(manifest.to_binary())
+    label: len(manifest)
     for label, (manifest, mesh) in meshes.items() 
   }
   meshes = {

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -105,6 +105,8 @@ def process_mesh(
   quantization_range = np.max(mesh.vertices, axis=0) - np.min(mesh.vertices, axis=0)
   quantization_range = np.max(quantization_range)
 
+  # mesh.vertices must be integer type or mesh will display
+  # distored in neuroglancer.
   mesh = DracoPy.encode_mesh_to_buffer(
     mesh.vertices.flatten('C'), mesh.faces.flatten('C'), 
     quantization_bits=vqb,

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -177,7 +177,7 @@ def MultiResShardedMeshMergeTask(
     for label, mesh_frags in tqdm(meshes.items(), disable=(not progress))
   }
   data_offset = { 
-    label: len(mesh) 
+    label: len(manifest.to_binary())
     for label, (manifest, mesh) in meshes.items() 
   }
   meshes = {

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -24,7 +24,6 @@ from cloudvolume.datasource.precomputed.sharding import synthesize_shard_files
 import mapbuffer
 from mapbuffer import MapBuffer
 from taskqueue import queueable
-import trimesh
 
 import cc3d
 import DracoPy

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -253,6 +253,9 @@ def collect_mesh_fragments(
         except KeyError:
           continue
 
+      if hasattr(content, "close"):
+        content.close()
+
   return all_meshes
 
 def locations_for_labels(

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -1,10 +1,11 @@
-from typing import Optional
+from typing import Optional, List, Dict
 
 from collections import defaultdict
-
+import itertools
 import json
 import math
 import os
+import pickle
 import random
 import re
 import struct
@@ -15,7 +16,7 @@ from tqdm import tqdm
 from cloudfiles import CloudFiles
 
 from cloudvolume import CloudVolume, Mesh, view
-from cloudvolume.lib import Vec, Bbox, jsonify
+from cloudvolume.lib import Vec, Bbox, jsonify, sip
 from cloudvolume.datasource.precomputed.mesh.multilod \
   import MultiLevelPrecomputedMeshManifest, to_stored_model_space
 import mapbuffer
@@ -31,6 +32,7 @@ import zmesh
 from .draco import draco_encoding_settings
 
 __all__ = [
+  "MultiResShardedMeshMergeTask",
   "MultiResUnshardedMeshMergeTask",
 ]
 
@@ -42,8 +44,7 @@ def MultiResUnshardedMeshMergeTask(
   draco_compression_level:int = 1,
   mesh_dir:Optional[str] = None,
   num_lod:int = 1,
-  # progress:bool = False,
-  # sharded:bool = False,
+  progress:bool = False,
 ):
   cv = CloudVolume(cloudpath)
   
@@ -55,46 +56,62 @@ def MultiResUnshardedMeshMergeTask(
   )
 
   cf = CloudFiles(cv.meta.join(cloudpath, mesh_dir))
-  for label, filenames in files_per_label.items():
+  for label, filenames in tqdm(files_per_label.items(), disable=(not progress)):
     files = cf.get(filenames)
     # we should handle draco as well
     files = [ Mesh.from_precomputed(f["content"]) for f in files ]
-    mesh = Mesh.concatenate(*files)
 
-    manifest = MultiLevelPrecomputedMeshManifest(
-      segment_id=label, 
-      chunk_shape=cv.bounds.size3(),
-      grid_origin=cv.bounds.minpt, 
-      num_lods=1, 
-      lod_scales=[ 1 ], 
-      vertex_offsets=[[0,0,0]],
-      num_fragments_per_lod=[1], 
-      fragment_positions=[[[0,0,0]]], 
-      fragment_offsets=[0], # needs to be set when we have the final value
+    (manifest, mesh) = process_mesh(
+      cv, label, files, 
+      num_lod, draco_compression_level
     )
-
-    vqb = int(cv.mesh.meta.info["vertex_quantization_bits"])
-
-    mesh.vertices /= cv.meta.resolution(cv.mesh.meta.mip)
-    mesh.vertices = to_stored_model_space(
-      mesh.vertices, manifest, 
-      lod=0, 
-      vertex_quantization_bits=vqb,
-      frag=0
-    )
-
-    mesh = DracoPy.encode_mesh_to_buffer(
-      mesh.vertices.flatten('C'), mesh.faces.flatten('C'), 
-      quantization_bits=vqb,
-      compression_level=draco_compression_level,
-      quantization_range=np.max(mesh.vertices),
-      quantization_origin=[0,0,0],
-      create_metadata=True,
-    )
-    manifest.fragment_offsets = [ len(mesh) ]
 
     cf.put(f"{label}.index", manifest.to_binary(), cache_control="no-cache")
     cf.put(f"{label}", mesh, cache_control="no-cache")
+
+def process_mesh(
+  cv:CloudVolume,
+  label:int,
+  mesh_fragments: List[Mesh],
+  num_lod:int = 1,
+  draco_compression_level:int = 1,
+) -> Tuple[MultiLevelPrecomputedMeshManifest, Mesh]:
+  
+  mesh = Mesh.concatenate(*files)
+
+  manifest = MultiLevelPrecomputedMeshManifest(
+    segment_id=label, 
+    chunk_shape=cv.bounds.size3(),
+    grid_origin=cv.bounds.minpt, 
+    num_lods=1, 
+    lod_scales=[ 1 ], 
+    vertex_offsets=[[0,0,0]],
+    num_fragments_per_lod=[1], 
+    fragment_positions=[[[0,0,0]]], 
+    fragment_offsets=[0], # needs to be set when we have the final value
+  )
+
+  vqb = int(cv.mesh.meta.info["vertex_quantization_bits"])
+
+  mesh.vertices /= cv.meta.resolution(cv.mesh.meta.mip)
+  mesh.vertices = to_stored_model_space(
+    mesh.vertices, manifest, 
+    lod=0, 
+    vertex_quantization_bits=vqb,
+    frag=0
+  )
+
+  mesh = DracoPy.encode_mesh_to_buffer(
+    mesh.vertices.flatten('C'), mesh.faces.flatten('C'), 
+    quantization_bits=vqb,
+    compression_level=draco_compression_level,
+    quantization_range=np.max(mesh.vertices),
+    quantization_origin=[0,0,0],
+    create_metadata=True,
+  )
+  manifest.fragment_offsets = [ len(mesh) ]
+
+  return (manifest, mesh)
 
 def get_mesh_filenames_subset(
   cloudpath:str, mesh_dir:str, prefix:str
@@ -122,8 +139,136 @@ def get_mesh_filenames_subset(
 
   return segids
 
+@queueable
+def MultiResShardedMeshMergeTask(
+  cloudpath:str, 
+  shard_no:str,
+  draco_compression_level:int = 1,
+  mesh_dir:Optional[str] = None,
+  num_lod:int = 1,  
+  spatial_index_db:Optional[str] = None,
+  progress:bool = False
+):
+  cv = CloudVolume(cloudpath, spatial_index_db=spatial_index_db)
+  cv.mip = cv.mesh.meta.mip
+  if mesh_dir is None and 'mesh' in cv.info:
+    mesh_dir = cv.info['mesh']
 
+  # This looks messy because we are trying to avoid retaining
+  # unnecessary memory. In the original iteration, this was 
+  # using 50 GB+ memory on minnie65. With changes to this
+  # and the spatial_index, we are getting it down to something reasonable.
+  locations = locations_for_labels(cv, labels_for_shard(cv, shard_no))
+  filenames = set(itertools.chain(*locations.values()))
+  labels = set(locations.keys())
+  del locations
+  meshes = collect_mesh_fragments(cv, labels, filenames)
+  del labels
+  del filenames
+  meshes = [ 
+    process_mesh(
+      cv, label, mesh_frags, 
+      num_lod, draco_compression_level
+    )
+    for label, mesh_frags in tqdm(meshes.items(), disable=(not progress))
+  ]
 
+  if len(meshes) == 0:
+    return
 
+  shard_files = synthesize_shard_files(cv.mesh.reader.spec, meshes)
+  del meshes
 
+  if len(shard_files) != 1:
+    raise ValueError(
+      "Only one shard file should be generated per task. Expected: {} Got: {} ".format(
+        str(shard_no), ", ".join(shard_files.keys())
+    ))
 
+  cf = CloudFiles(cv.mesh.meta.layerpath, progress=progress)
+  cf.puts( 
+    ( (fname, data) for fname, data in shard_files.items() ),
+    compress=False,
+    content_type='application/octet-stream',
+    cache_control='no-cache',      
+  )
+
+def collect_mesh_fragments(
+  cv:CloudVolume, 
+  labels:List[int], 
+  filenames:List[str], 
+  mesh_dir:str, 
+  progress:bool = False
+) -> Dict[int, List[Mesh]]:
+  dirfn = lambda loc: cv.meta.join(mesh_dir, loc)
+  filenames = [ dirfn(loc) for loc in filenames ]
+
+  block_size = 50
+
+  if len(filenames) < block_size:
+    blocks = [ filenames ]
+    n_blocks = 1
+  else:
+    n_blocks = max(len(filenames) // block_size, 1)
+    blocks = sip(filenames, block_size)
+
+  all_meshes = defaultdict(list)
+  for filenames_block in tqdm(blocks, desc="Filename Block", total=n_blocks, disable=(not progress)):
+    if cv.meta.path.protocol == "file":
+      all_files = {}
+      prefix = cv.cloudpath.replace("file://", "")
+      for filename in filenames_block:
+        f = open(os.path.join(prefix, filename), "rb")
+        all_files[filename] = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
+    else:
+      all_files = cv.mesh.cache.download(filenames_block, progress=progress)
+    
+    for filename, content in tqdm(all_files.items(), desc="Scanning Fragments", disable=(not progress)):
+      try:
+        fragment = MapBuffer(content, frombytesfn=Mesh.from_precomputed)
+        fragment.validate()
+      except mapbuffer.ValidationError:
+        fragment = pickle.loads(content)
+
+      for label in labels:
+        try:
+          mesh = fragment[label]
+          mesh.id = label
+          all_meshes[label].append(mesh)
+        except KeyError:
+          continue
+
+  return all_meshes
+
+def locations_for_labels(
+  cv:CloudVolume, labels:List[int]
+) -> Dict[int, List[str]]:
+
+  SPATIAL_EXT = re.compile(r'\.spatial$')
+  index_filenames = cv.mesh.spatial_index.file_locations_per_label(labels)
+  for label, locations in index_filenames.items():
+    for i, location in enumerate(locations):
+      bbx = Bbox.from_filename(re.sub(SPATIAL_EXT, '', location))
+      bbx /= cv.meta.resolution(cv.mesh.meta.mip)
+      index_filenames[label][i] = bbx.to_filename() + '.frags'
+  return index_filenames
+
+def labels_for_shard(
+  cv:CloudVolume, shard_no:str, progress:bool = False
+) -> List[int]:
+  """
+  Try to fetch precalculated labels from `$shardno.labels` (faster) otherwise, 
+  compute which labels are applicable to this shard from the shard index (much slower).
+  """
+  labels = CloudFiles(cv.mesh.meta.layerpath).get_json(shard_no + '.labels')
+  if labels is not None:
+    return labels
+
+  labels = cv.mesh.spatial_index.query(cv.bounds * cv.resolution)
+  spec = cv.mesh.reader.spec
+
+  return [ 
+    lbl for lbl in tqdm(labels, desc="Computing Shard Numbers", disable=(not progress))  \
+    if spec.compute_shard_location(lbl).shard_number == shard_no 
+  ]
+  

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple
 
 from collections import defaultdict
 import itertools

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -157,9 +157,9 @@ def MultiResShardedMeshMergeTask(
     mesh_dir = cv.info['mesh']
 
   # This looks messy because we are trying to avoid retaining
-  # unnecessary memory. In the original iteration, this was 
-  # using 50 GB+ memory on minnie65. With changes to this
-  # and the spatial_index, we are getting it down to something reasonable.
+  # unnecessary memory. In the original skeleton iteration, this was 
+  # using 50 GB+ memory on minnie65. So it makes sense to be just
+  # as careful with a heavier type of object.
   locations = locations_for_labels(cv, labels_for_shard(cv, shard_no))
   filenames = set(itertools.chain(*locations.values()))
   labels = set(locations.keys())

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -107,8 +107,8 @@ def process_mesh(
 
   # mesh.vertices must be integer type or mesh will display
   # distored in neuroglancer.
-  mesh = DracoPy.encode_mesh_to_buffer(
-    mesh.vertices.flatten('C'), mesh.faces.flatten('C'), 
+  mesh = DracoPy.encode(
+    mesh.vertices, mesh.faces, 
     quantization_bits=vqb,
     compression_level=draco_compression_level,
     quantization_range=quantization_range,

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -239,11 +239,8 @@ def collect_mesh_fragments(
       all_files = cv.mesh.cache.download(filenames_block, progress=progress)
     
     for filename, content in tqdm(all_files.items(), desc="Scanning Fragments", disable=(not progress)):
-      try:
-        fragment = MapBuffer(content, frombytesfn=Mesh.from_precomputed)
-        fragment.validate()
-      except mapbuffer.ValidationError:
-        fragment = pickle.loads(content)
+      fragment = MapBuffer(content, frombytesfn=Mesh.from_precomputed)
+      fragment.validate()
 
       for label in labels:
         try:

--- a/igneous/tasks/skeleton.py
+++ b/igneous/tasks/skeleton.py
@@ -403,8 +403,7 @@ class ShardedSkeletonMergeTask(RegisteredTask):
         all_files = {}
         prefix = cv.cloudpath.replace("file://", "")
         for filename in filenames_block:
-          f = open(os.path.join(prefix, filename), "rb")
-          all_files[filename] = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
+          all_files[filename] = open(os.path.join(prefix, filename), "rb")
       else:
         all_files = cv.skeleton.cache.download(filenames_block, progress=self.progress)
       
@@ -422,6 +421,9 @@ class ShardedSkeletonMergeTask(RegisteredTask):
             all_skels[label].append(skel)
           except KeyError:
             continue
+
+        if hasattr(content, "close"):
+          content.close()
 
     return all_skels
 

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -438,16 +438,15 @@ def mesh_merge(ctx, path, queue, magnitude, dir):
 @click.option('--queue', required=True, help="AWS SQS queue or directory to be used for a task queue. e.g. sqs://my-queue or ./my-queue. See https://github.com/seung-lab/python-task-queue", type=str)
 @click.option('--vqb', default=16, help="Vertex quantization bits. Can be 10 or 16.", type=int, show_default=True)
 @click.option('--compress-level', default=1, help="Draco compression level.", type=int, show_default=True)
-@click.option('--preshift-bits', default=3, help="Shift LSB to try to increase number of hash collisions.", type=int, show_default=True)
-@click.option('--minishard-bits', default=10, help="2^bits number of bays holding variable numbers of labels per shard.", type=int, show_default=True)
-@click.option('--shard-bits', default=2, help="2^bits number of shard files to generate.", type=int, show_default=True)
+@click.option('--shard-index-bytes', default=2**13, help="Size in bytes to make the shard index.", type=int, show_default=True)
+@click.option('--minishard-index-bytes', default=2**15, help="Size in bytes to make the minishard index.", type=int, show_default=True)
 @click.option('--minishard-index-encoding', default="gzip", help="Minishard indices can be compressed. gzip or raw.", show_default=True)
 @click.option('--spatial-index-db', default=None, help="CloudVolume generated SQL database for spatial index.", show_default=True)
 @click.pass_context
 def mesh_sharded_merge(
   ctx, path, queue, 
   vqb, compress_level,
-  preshift_bits, minishard_bits, shard_bits,
+  shard_index_bytes, minishard_index_bytes,
   minishard_index_encoding, spatial_index_db
 ):
   """
@@ -458,15 +457,17 @@ def mesh_sharded_merge(
   are selected for a dataset with a few million labels,
   but for smaller or larger datasets they may not be
   appropriate.
+
+  The shard and minishard index default sizes are set to
+  accomodate efficient access for a 100 Mbps connection.
   """
   path = cloudfiles.paths.normalize(path)
   tasks = tc.create_sharded_multires_mesh_tasks(
     path, 
     draco_compression_level=compress_level,
     vertex_quantization_bits=vqb,
-    preshift_bits=preshift_bits,
-    minishard_bits=minishard_bits,
-    shard_bits=shard_bits,
+    shard_index_bytes=shard_index_bytes,
+    minishard_index_bytes=minishard_index_bytes,
     minishard_index_encoding=minishard_index_encoding,
     spatial_index_db=spatial_index_db,
   )

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -434,12 +434,14 @@ def mesh_merge(ctx, path, queue, magnitude, dir):
 @click.option('--shard-bits', default=2, help="2^bits number of shard files to generate.", type=int, show_default=True)
 @click.option('--minishard-index-encoding', default="gzip", help="Minishard indices can be compressed. gzip or raw.", show_default=True)
 @click.option('--data-encoding', default="gzip", help="Shard data can be compressed. gzip or raw.", show_default=True)
+@click.option('--spatial-index-db', default=None, help="CloudVolume generated SQL database for spatial index.", show_default=True)
 @click.pass_context
 def mesh_sharded_merge(
   ctx, path, queue, 
   vqb, compress_level,
   preshift_bits, minishard_bits, shard_bits,
-  minishard_index_encoding, data_encoding
+  minishard_index_encoding, data_encoding,
+  spatial_index_db
 ):
   """
   (2) Postprocess fragments into finished sharded multires meshes.
@@ -459,6 +461,7 @@ def mesh_sharded_merge(
     shard_bits=shard_bits,
     minishard_index_encoding=minishard_index_encoding, 
     data_encoding=data_encoding,
+    spatial_index_db=spatial_index_db,
   )
 
   parallel = int(ctx.obj.get("parallel", 1))
@@ -622,13 +625,15 @@ def skeleton_merge(
 @click.option('--shard-bits', default=2, help="2^bits number of shard files to generate.", type=int)
 @click.option('--minishard-index-encoding', default="gzip", help="Minishard indices can be compressed. gzip or raw. Default: gzip")
 @click.option('--data-encoding', default="gzip", help="Shard data can be compressed. gzip or raw. Default: gzip")
+@click.option('--spatial-index-db', default=None, help="CloudVolume generated SQL database for spatial index.", show_default=True)
 @click.pass_context
 def skeleton_sharded_merge(
   ctx, path, queue, 
   min_cable_length, max_cable_length, 
   tick_threshold, 
   preshift_bits, minishard_bits, shard_bits,
-  minishard_index_encoding, data_encoding
+  minishard_index_encoding, data_encoding,
+  spatial_index_db
 ):
   """
   (2) Postprocess fragments into finished skeletons.
@@ -649,6 +654,7 @@ def skeleton_sharded_merge(
     shard_bits=shard_bits,
     minishard_index_encoding=minishard_index_encoding, 
     data_encoding=data_encoding,
+    spatial_index_db=spatial_index_db,
   )
 
   parallel = int(ctx.obj.get("parallel", 1))

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -819,7 +819,8 @@ def memory_used(data_width, shape, factor):
 @click.argument("path")
 @click.option('--browser/--no-browser', default=True, is_flag=True, help="Open the dataset in the system's default web browser.")
 @click.option('--port', default=1337, help="localhost server port for the file server.", show_default=True)
-def view(path, browser, port):
+@click.option('--ng', default="https://neuroglancer-demo.appspot.com/", help="Alternative Neuroglancer webpage to use.", show_default=True)
+def view(path, browser, port, ng):
   """
   Open an on-disk dataset for viewing in neuroglancer.
   """
@@ -827,7 +828,7 @@ def view(path, browser, port):
   #   could use local neuroglancer
   #   modify the url to autopopulate params to avoid a click
   path = cloudfiles.paths.normalize(path)
-  url = f"https://neuroglancer-demo.appspot.com/#!%7B%22layers%22:%5B%7B%22type%22:%22new%22%2C%22source%22:%22precomputed://http://localhost:{port}%22%2C%22tab%22:%22source%22%2C%22name%22:%22localhost:{port}%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22localhost:{port}%22%7D%2C%22layout%22:%224panel%22%7D"
+  url = f"{ng}#!%7B%22layers%22:%5B%7B%22type%22:%22new%22%2C%22source%22:%22precomputed://http://localhost:{port}%22%2C%22tab%22:%22source%22%2C%22name%22:%22localhost:{port}%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22localhost:{port}%22%7D%2C%22layout%22:%224panel%22%7D"
   if browser:
     webbrowser.open(url, new=2)
   CloudVolume(path).viewer(port=port)

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -133,6 +133,8 @@ def downsample(
   current top mip level of the pyramid. This builds it even taller
   (referred to as "superdownsampling").
   """
+  path = cloudfiles.paths.normalize(path)
+
   if cseg and compresso:
     print("igneous: must choose one of --cseg or --compresso")
     return
@@ -237,6 +239,9 @@ def xfer(
   Use the --memory flag to automatically compute the
   a reasonable task shape based on your memory limits.
   """
+  src = cloudfiles.paths.normalize(src)
+  dest = cloudfiles.paths.normalize(dest)
+
   if cseg and compresso:
     print("igneous: must choose one of --cseg or --compresso")
     sys.exit()
@@ -388,6 +393,7 @@ def mesh_forge(
 
   Sharded format not currently supports. Coming soon.
   """
+  path = cloudfiles.paths.normalize(path)
   if compress.lower() == "none":
     compress = False
 
@@ -455,6 +461,7 @@ def mesh_sharded_merge(
   but for smaller or larger datasets they may not be
   appropriate.
   """
+  path = cloudfiles.paths.normalize(path)
   tasks = tc.create_sharded_multires_mesh_tasks(
     path, 
     draco_compression_level=compress_level,
@@ -487,6 +494,7 @@ def mesh_spatial_index(ctx, path, queue, shape, mip, fill_missing):
   This function provides a more efficient
   way to accomplish that than remeshing.
   """
+  path = cloudfiles.paths.normalize(path)
   tasks = tc.create_spatial_index_mesh_tasks(
     cloudpath=path,
     shape=shape,
@@ -559,6 +567,7 @@ def skeleton_forge(
 
   - https://github.com/seung-lab/kimimaro/wiki/The-Economics:-Skeletons-for-the-People
   """
+  path = cloudfiles.paths.normalize(path)
   teasar_params = {
     'scale': scale,
     'const': const, # physical units
@@ -604,6 +613,7 @@ def skeleton_merge(
   """
   (2) Postprocess fragments into finished skeletons.
   """
+  path = cloudfiles.paths.normalize(path)
   tasks = tc.create_unsharded_skeleton_merge_tasks(
     path, 
     magnitude=magnitude, 
@@ -686,6 +696,7 @@ def delete_images(
   """
   Delete the image layer of a dataset.
   """
+  path = cloudfiles.paths.normalize(path)
   tasks = tc.create_deletion_tasks(
     path, mip, num_mips=num_mips, shape=shape
   )
@@ -709,6 +720,7 @@ def dsbounds(path, mip):
   an unsharded image volume. Useful when there
   is a corrupted info file.
   """
+  path = cloudfiles.paths.normalize(path)
   cv = CloudVolume(path, mip=mip)
   cf = CloudFiles(path)
 
@@ -735,6 +747,7 @@ def dsmemory(path, memory_bytes, mip, factor, verbose, max_mips):
   Compute the task shape that maximizes the number of
   downsamples for a given amount of memory.
   """ 
+  path = cloudfiles.paths.normalize(path)
   cv = CloudVolume(path, mip=mip)
 
   data_width = np.dtype(cv.dtype).itemsize
@@ -782,6 +795,7 @@ def dsshape(path, shape, mip, factor):
   Compute the approximate memory usage for a
   given downsample task shape.
   """ 
+  path = cloudfiles.paths.normalize(path)
   cv = CloudVolume(path, mip=mip)
   data_width = np.dtype(cv.dtype).itemsize
   memory_bytes = memory_used(data_width, shape, factor)  
@@ -812,8 +826,8 @@ def view(path, browser, port):
   # later improvements: 
   #   could use local neuroglancer
   #   modify the url to autopopulate params to avoid a click
-
+  path = cloudfiles.paths.normalize(path)
   url = f"https://neuroglancer-demo.appspot.com/#!%7B%22layers%22:%5B%7B%22type%22:%22new%22%2C%22source%22:%22precomputed://http://localhost:{port}%22%2C%22tab%22:%22source%22%2C%22name%22:%22localhost:{port}%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22localhost:{port}%22%7D%2C%22layout%22:%224panel%22%7D"
   if browser:
     webbrowser.open(url, new=2)
-  CloudVolume(cloudfiles.paths.normalize(path)).viewer(port=port)
+  CloudVolume(path).viewer(port=port)

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -628,12 +628,11 @@ def skeleton_merge(
 @skeletongroup.command("merge-sharded")
 @click.argument("path")
 @click.option('--queue', required=True, help="AWS SQS queue or directory to be used for a task queue. e.g. sqs://my-queue or ./my-queue. See https://github.com/seung-lab/python-task-queue", type=str)
-@click.option('--min-cable-length', default=1000, help="Skip objects smaller than this physical path length. Default: 1000 nm", type=float)
+@click.option('--min-cable-length', default=1000, help="Skip objects smaller than this physical path length.", type=float, show_default=True)
 @click.option('--max-cable-length', default=None, help="Skip objects larger than this physical path length. Default: no limit", type=float)
 @click.option('--tick-threshold', default=0, help="Remove small \"ticks\", or branches from the main skeleton one at a time from smallest to largest. Branches larger than this are preserved. Default: no elimination", type=float)
-@click.option('--preshift-bits', default=3, help="Shift LSB to try to increase number of hash collisions.", type=int)
-@click.option('--minishard-bits', default=10, help="2^bits number of bays holding variable numbers of labels per shard.", type=int)
-@click.option('--shard-bits', default=2, help="2^bits number of shard files to generate.", type=int)
+@click.option('--shard-index-bytes', default=2**13, help="Size in bytes to make the shard index.", type=int, show_default=True)
+@click.option('--minishard-index-bytes', default=2**15, help="Size in bytes to make the minishard index.", type=int, show_default=True)
 @click.option('--minishard-index-encoding', default="gzip", help="Minishard indices can be compressed. gzip or raw. Default: gzip")
 @click.option('--data-encoding', default="gzip", help="Shard data can be compressed. gzip or raw. Default: gzip")
 @click.option('--spatial-index-db', default=None, help="CloudVolume generated SQL database for spatial index.", show_default=True)
@@ -642,7 +641,7 @@ def skeleton_sharded_merge(
   ctx, path, queue, 
   min_cable_length, max_cable_length, 
   tick_threshold, 
-  preshift_bits, minishard_bits, shard_bits,
+  shard_index_bytes, minishard_index_bytes,
   minishard_index_encoding, data_encoding,
   spatial_index_db
 ):
@@ -654,15 +653,17 @@ def skeleton_sharded_merge(
   are selected for a dataset with a few million labels,
   but for smaller or larger datasets they may not be
   appropriate.
+
+  The shard and minishard index default sizes are set to
+  accomodate efficient access for a 100 Mbps connection.
   """
   tasks = tc.create_sharded_skeleton_merge_tasks(
     path, 
     dust_threshold=min_cable_length,
     max_cable_length=max_cable_length,
     tick_threshold=tick_threshold,
-    preshift_bits=preshift_bits, 
-    minishard_bits=minishard_bits, 
-    shard_bits=shard_bits,
+    shard_index_bytes=shard_index_bytes,
+    minishard_index_bytes=minishard_index_bytes,
     minishard_index_encoding=minishard_index_encoding, 
     data_encoding=data_encoding,
     spatial_index_db=spatial_index_db,

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -425,6 +425,7 @@ def mesh_merge(ctx, path, queue, magnitude, dir):
   a list of fragment files and uploading a "mesh manifest"
   file that is an index for locating the fragments.
   """
+  path = cloudfiles.paths.normalize(path)
   tasks = tc.create_mesh_manifest_tasks(
     path, magnitude=magnitude, mesh_dir=dir
   )

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -442,15 +442,13 @@ def mesh_merge(ctx, path, queue, magnitude, dir):
 @click.option('--minishard-bits', default=10, help="2^bits number of bays holding variable numbers of labels per shard.", type=int, show_default=True)
 @click.option('--shard-bits', default=2, help="2^bits number of shard files to generate.", type=int, show_default=True)
 @click.option('--minishard-index-encoding', default="gzip", help="Minishard indices can be compressed. gzip or raw.", show_default=True)
-@click.option('--data-encoding', default="gzip", help="Shard data can be compressed. gzip or raw.", show_default=True)
 @click.option('--spatial-index-db', default=None, help="CloudVolume generated SQL database for spatial index.", show_default=True)
 @click.pass_context
 def mesh_sharded_merge(
   ctx, path, queue, 
   vqb, compress_level,
   preshift_bits, minishard_bits, shard_bits,
-  minishard_index_encoding, data_encoding,
-  spatial_index_db
+  minishard_index_encoding, spatial_index_db
 ):
   """
   (2) Postprocess fragments into finished sharded multires meshes.
@@ -466,11 +464,10 @@ def mesh_sharded_merge(
     path, 
     draco_compression_level=compress_level,
     vertex_quantization_bits=vqb,
-    preshift_bits=preshift_bits, 
-    minishard_bits=minishard_bits, 
+    preshift_bits=preshift_bits,
+    minishard_bits=minishard_bits,
     shard_bits=shard_bits,
-    minishard_index_encoding=minishard_index_encoding, 
-    data_encoding=data_encoding,
+    minishard_index_encoding=minishard_index_encoding,
     spatial_index_db=spatial_index_db,
   )
 

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -3,11 +3,14 @@ import math
 import multiprocessing as mp
 import os
 import sys
+import time
+import webbrowser
 
 import click
 from cloudvolume import CloudVolume, Bbox
 from cloudvolume.lib import max2
 from cloudfiles import CloudFiles
+import cloudfiles.paths
 import numpy as np
 from taskqueue import TaskQueue
 from taskqueue.lib import toabs
@@ -797,3 +800,20 @@ def memory_used(data_width, shape, factor):
     memory_bytes *= constant / (constant - 1)
 
   return memory_bytes
+
+@main.command("view")
+@click.argument("path")
+@click.option('--browser/--no-browser', default=True, is_flag=True, help="Open the dataset in the system's default web browser.")
+@click.option('--port', default=1337, help="localhost server port for the file server.", show_default=True)
+def view(path, browser, port):
+  """
+  Open an on-disk dataset for viewing in neuroglancer.
+  """
+  # later improvements: 
+  #   could use local neuroglancer
+  #   modify the url to autopopulate params to avoid a click
+
+  url = f"https://neuroglancer-demo.appspot.com/#!%7B%22layers%22:%5B%7B%22type%22:%22new%22%2C%22source%22:%22precomputed://http://localhost:{port}%22%2C%22tab%22:%22source%22%2C%22name%22:%22localhost:{port}%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22localhost:{port}%22%7D%2C%22layout%22:%224panel%22%7D"
+  if browser:
+    webbrowser.open(url, new=2)
+  CloudVolume(cloudfiles.paths.normalize(path)).viewer(port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=6.7
 cloud-files>=4.4.0
-cloud-volume>=6.0.0
+cloud-volume>=6.1.0
 DracoPy>=0.0.19
 fastremap>=1.10.0
 google-cloud-logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=6.7
-cloud-volume>=4.2.0
+cloud-volume>=6.0.0
 DracoPy>=0.0.19
 fastremap>=1.10.0
 google-cloud-logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click>=6.7
+cloud-files>=4.4.0
 cloud-volume>=6.0.0
 DracoPy>=0.0.19
 fastremap>=1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ DracoPy>=0.0.19
 fastremap>=1.10.0
 google-cloud-logging
 kimimaro>=0.5.0
-mapbuffer>=0.1.1
+mapbuffer>=0.4.0
 networkx
 numpy>=1.14.2
 pathos

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click>=6.7
 cloud-files>=4.4.0
-cloud-volume>=6.1.0
-DracoPy>=0.0.19
+cloud-volume>=7.0.0
+DracoPy~=1.0.0
 fastremap>=1.10.0
 google-cloud-logging
 kimimaro>=0.5.0

--- a/test/test_shards.py
+++ b/test/test_shards.py
@@ -178,7 +178,3 @@ def test_shard_bits_calculation_for_hashed():
   assert msb == 9
   assert sb == 13
 
-
-
-
-

--- a/test/test_shards.py
+++ b/test/test_shards.py
@@ -10,8 +10,8 @@ from cloudvolume.datasource.precomputed.image.common import (
 )
 from cloudvolume.datasource.precomputed.sharding import ShardReader, ShardingSpecification
 
+from igneous.task_creation.common import compute_shard_params_for_hashed
 from igneous.task_creation.image import create_sharded_image_info
-from igneous.task_creation.mesh import compute_shard_params_for_hashed
 from igneous.shards import image_shard_shape_from_spec
 
 def prod(x):

--- a/test/test_shards.py
+++ b/test/test_shards.py
@@ -11,6 +11,7 @@ from cloudvolume.datasource.precomputed.image.common import (
 from cloudvolume.datasource.precomputed.sharding import ShardReader, ShardingSpecification
 
 from igneous.task_creation.image import create_sharded_image_info
+from igneous.task_creation.mesh import compute_shard_params_for_hashed
 from igneous.shards import image_shard_shape_from_spec
 
 def prod(x):
@@ -103,4 +104,81 @@ def test_broken_dataset():
   )
   total_bits = spec["shard_bits"] + spec["minishard_bits"] + spec["preshift_bits"]
   assert total_bits == 20
+
+def test_shard_bits_calculation_for_hashed():
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**9, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 9
+  assert sb == 11
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**6, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 9
+  assert sb == 1
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**7, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 9
+  assert sb == 4
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=1000, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 0
+  assert sb == 0
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=0, 
+    shard_index_bytes=0, 
+    minishard_index_bytes=0
+  )
+  assert psb == 0
+  assert msb == 0
+  assert sb == 0
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10000, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 3
+  assert sb == 0
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**9, 
+    shard_index_bytes=2**10, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 6
+  assert sb == 14
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**9, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**13
+  )
+  assert psb == 0
+  assert msb == 9
+  assert sb == 13
+
+
+
+
 


### PR DESCRIPTION
Adds several new features:

- `igneous view $DATASET` to open an on-disk dataset in neuroglancer
- `igneous mesh ... --sharded` generates fragments
- `igneous mesh merge-sharded ....`
- Changes sharded skeletons to automatically compute sharding config
- Create spatial index database from meshes `igneous mesh spatial-index create $PATH` `igneous mesh spatial-index db $PATH $DATABASE`