### PR TITLE
fix: Add kwarg for updated get_bounds

### DIFF
--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -205,7 +205,7 @@ def create_downsampling_tasks(
     if not preserve_chunk_size or chunk_size:
       shape = ds_shape(mip + 1, chunk_size, factor)
 
-    bounds = get_bounds(vol, bounds, mip, vol.chunk_size)
+    bounds = get_bounds(vol, bounds, mip, chunk_size=vol.chunk_size)
     
     class DownsampleTaskIterator(FinelyDividedTaskIterator):
       def task(self, shape, offset):


### PR DESCRIPTION
This fixes `get_bounds` calls that rely on positional arguments that I broke in PR #108.