### PR TITLE
redesign(cli): change --cseg and --compresso flags to --encoding

### DIFF
--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -98,8 +98,7 @@ def license():
 @click.option('--mip', default=0, help="Build upward from this level of the image pyramid. Default: 0")
 @click.option('--fill-missing', is_flag=True, default=False, help="Interpret missing image files as background instead of failing.")
 @click.option('--num-mips', default=5, help="Build this many additional pyramid levels. Each increment increases memory requirements per task 4-8x.  Default: 5")
-@click.option('--cseg', is_flag=True, default=False, help="Use the compressed_segmentation image chunk encoding scheme. Segmentation only.")
-@click.option('--compresso', is_flag=True, default=False, help="Use the compresso image chunk encoding scheme. Segmentation only.")
+@click.option('--encoding', default="raw", help="Which image encoding to use. Options: [all] raw, png; [images] jpeg; [segmentations] cseg, compresso; [floats] fpzip, kempressed", show_default=True)
 @click.option('--sparse', is_flag=True, default=False, help="Don't count black pixels in mode or average calculations. For images, eliminates edge ghosting in 2x2x2 downsample. For segmentation, prevents small objects from disappearing at high mip levels.")
 @click.option('--chunk-size', type=Tuple3(), default=None, help="Chunk size of new layers. e.g. 128,128,64")
 @click.option('--compress', default=None, help="Set the image compression scheme. Options: 'gzip', 'br'")
@@ -114,7 +113,7 @@ def license():
 @click.pass_context
 def downsample(
   ctx, path, queue, mip, fill_missing, 
-  num_mips, cseg, compresso, sparse, 
+  num_mips, encoding, sparse, 
   chunk_size, compress, volumetric,
   delete_bg, bg_color, sharded, memory,
   xrange, yrange, zrange
@@ -135,19 +134,12 @@ def downsample(
   """
   path = cloudfiles.paths.normalize(path)
 
-  if cseg and compresso:
-    print("igneous: must choose one of --cseg or --compresso")
-    return
-
   if sharded and num_mips != 1:
     print("igneous: sharded downsamples only support producing one mip at a time.")
     return
 
-  encoding = None
-  if cseg:
+  if encoding == "cseg":
     encoding = "compressed_segmentation"
-  elif compresso:
-    encoding = "compresso"
 
   factor = (2,2,1)
   if volumetric:

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -56,7 +56,7 @@ class Tuple2(click.ParamType):
 
 @click.group()
 @click.option("-p", "--parallel", default=1, help="Run with this number of parallel processes. If 0, use number of cores.")
-@click.version_option(version="1.0.0")
+@click.version_option(version="2.0.0")
 @click.pass_context
 def main(ctx, parallel):
   """

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -200,8 +200,7 @@ def downsample(
 @click.option('--fill-missing', is_flag=True, default=False, help="Interpret missing image files as background instead of failing.")
 @click.option('--memory', default=3.5e9, type=int, help="Task memory limit in bytes. Task shape will be chosen to fit and maximize downsamples.", show_default=True)
 @click.option('--max-mips', default=5, help="Maximum number of additional pyramid levels.", show_default=True)
-@click.option('--cseg', is_flag=True, default=False, help="Use the compressed_segmentation image chunk encoding scheme. Segmentation only.")
-@click.option('--compresso', is_flag=True, default=False, help="Use the compresso image chunk encoding scheme. Segmentation only.")
+@click.option('--encoding', default="raw", help="Which image encoding to use. Options: [all] raw, png; [images] jpeg; [segmentations] cseg, compresso; [floats] fpzip, kempressed", show_default=True)
 @click.option('--sparse', is_flag=True, default=False, help="Don't count black pixels in mode or average calculations. For images, eliminates edge ghosting in 2x2x2 downsample. For segmentation, prevents small objects from disappearing at high mip levels.")
 @click.option('--shape', type=Tuple3(), default=(2048, 2048, 64), help="(overrides --memory) Set the task shape in voxels. This also determines how many downsamples you get. e.g. 2048,2048,64")
 @click.option('--chunk-size', type=Tuple3(), default=None, help="Chunk size of destination layer. e.g. 128,128,64")
@@ -218,7 +217,7 @@ def xfer(
 	ctx, src, dest, queue, translate, 
   downsample, mip, fill_missing, 
   memory, max_mips, shape, sparse, 
-  cseg, compresso, chunk_size, compress, 
+  encoding, chunk_size, compress, 
   volumetric, delete_bg, bg_color, sharded,
   dest_voxel_offset, clean_info, no_src_update
 ):
@@ -243,15 +242,8 @@ def xfer(
   src = cloudfiles.paths.normalize(src)
   dest = cloudfiles.paths.normalize(dest)
 
-  if cseg and compresso:
-    print("igneous: must choose one of --cseg or --compresso")
-    sys.exit()
-
-  encoding = None
-  if cseg:
+  if encoding == "cseg":
     encoding = "compressed_segmentation"
-  elif compresso:
-    encoding = "compresso"
 
   factor = (2,2,1)
   if volumetric:


### PR DESCRIPTION
We offer wayyy more formats than just cseg and compresso (jpeg, raw, png, fpzip, kempressed, just to name a few). The user should be able to pick whatever they want.