### PR TITLE
Trivial Errors in ContrastNormalizationTask

### DIFF
--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -881,6 +881,8 @@ def create_contrast_normalization_tasks(
     dvol.info['scales'] = dvol.info['scales'][:mip+1]
     dvol.commit_info()
 
+  bounds = get_bounds(srcvol, bounds, mip, bounds_mip=bounds_mip)
+  
   if shape == None:
     shape = Bbox( (0,0,0), (2048, 2048, 64) )
     shape = shape.shrink_to_chunk_size(dvol.underlying).size3()
@@ -890,9 +892,7 @@ def create_contrast_normalization_tasks(
 
   downsample_scales.create_downsample_scales(dest_path, mip=mip, ds_shape=shape, preserve_chunk_size=True)
   dvol.refresh_info()
-
-  bounds = get_bounds(srcvol, bounds, mip, bounds_mip=bounds_mip)
-
+  
   class ContrastNormalizationTaskIterator(FinelyDividedTaskIterator):
     def task(self, shape, offset):
       task_shape = min2(shape.clone(), srcvol.bounds.maxpt - offset)

--- a/igneous/tasks/image.py
+++ b/igneous/tasks/image.py
@@ -214,7 +214,10 @@ class ContrastNormalizationTask(RegisteredTask):
     image = np.clip(image, minval, maxval).astype(destcv.dtype)
 
     bounds += self.translate
-    downsample_and_upload(image, bounds, destcv, self.shape, mip=self.mip)
+    if downsample:
+      downsample_and_upload(image, bounds, destcv, self.shape, mip=self.mip)
+    else:
+      destcv[bounds.to_slices()] = image
 
   def find_section_clamping_values(self, zlevel, lowerfract, upperfract):
     filtered = np.copy(zlevel)

--- a/igneous/tasks/image.py
+++ b/igneous/tasks/image.py
@@ -214,10 +214,7 @@ class ContrastNormalizationTask(RegisteredTask):
     image = np.clip(image, minval, maxval).astype(destcv.dtype)
 
     bounds += self.translate
-    if downsample:
-      downsample_and_upload(image, bounds, destcv, self.shape, mip=self.mip)
-    else:
-      destcv[bounds.to_slices()] = image
+    destcv[bounds.to_slices()] = image
 
   def find_section_clamping_values(self, zlevel, lowerfract, upperfract):
     filtered = np.copy(zlevel)


### PR DESCRIPTION
igneous/task_creation/image.py
    'bounds' uses before definition.

igneous/tasks/image.py
    The automatic downsample_and_upload() may cause error (e.g. all 10000 and chunk 512).
    And I think letting users do downsample tasks by themselves may be better.