### PR TITLE
fix: use factor arg within create_transfer_tasks

### DIFF
--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -800,7 +800,7 @@ def create_transfer_tasks(
 
   if not skip_downsamples:
     downsample_scales.create_downsample_scales(dest_layer_path, 
-      mip=mip, ds_shape=shape, 
+      mip=mip, ds_shape=shape, factor=factor,
       preserve_chunk_size=preserve_chunk_size,
       encoding=encoding
     )


### PR DESCRIPTION
`create_transfer_tasks` currently doesn't pass its `factor` kwarg to `create_downsample_scales` which assumes `factor=(2, 2, 1)`. If the user wants a different downsampling factor this results in inconsistent downsampled layers.