### PR TITLE
feat: add encoding level to transfer tasks

### DIFF
--- a/igneous/task_creation/common.py
+++ b/igneous/task_creation/common.py
@@ -213,7 +213,7 @@ def compute_shard_params_for_hashed(
   return (int(shard_bits), int(minishard_bits), 0)
 
 def set_encoding(cv, mip, encoding, encoding_level):
-  scale = cv.scale(mip)
+  scale = cv.meta.scale(mip)
   if encoding is not None:
     scale['encoding'] = encoding
     if encoding == 'compressed_segmentation' and 'compressed_segmentation_block_size' not in scale:

--- a/igneous/task_creation/common.py
+++ b/igneous/task_creation/common.py
@@ -211,3 +211,24 @@ def compute_shard_params_for_hashed(
   minishard_bits = max(minishard_bits, 0)
 
   return (int(shard_bits), int(minishard_bits), 0)
+
+def set_encoding(cv, mip, encoding, encoding_level):
+  scale = cv.scale(mip)
+  if encoding is not None:
+    scale['encoding'] = encoding
+    if encoding == 'compressed_segmentation' and 'compressed_segmentation_block_size' not in scale:
+      scale['compressed_segmentation_block_size'] = (8,8,8)
+
+  if encoding_level is None:
+    return
+
+  encoding_level = int(encoding_level)
+
+  if encoding == "jpeg":
+    scale["jpeg_quality"] = encoding_level
+  elif encoding == "png":
+    scale["png_level"] = encoding_level
+  elif encoding == "fpzip":
+    scale["fpzip_precision"] = encoding_level
+
+

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -496,7 +496,6 @@ def create_image_shard_transfer_tasks(
         mip=mip,
         agglomerate=agglomerate,
         timestamp=timestamp,
-        encoding_level=encoding_level,
       )
 
     def on_finish(self):
@@ -837,7 +836,6 @@ def create_transfer_tasks(
         compress=compress,
         factor=factor,
         sparse=sparse,
-        encoding_level=encoding_level,
       )
 
     def on_finish(self):

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -443,6 +443,11 @@ def create_image_shard_transfer_tasks(
     info = copy.deepcopy(src_vol.info)
     dest_vol = CloudVolume(dst_layer_path, info=info, mip=mip)
     dest_vol.commit_info()
+  except cloudvolume.exceptions.ScaleUnavailableError:
+    dest_vol = CloudVolume(dst_layer_path)
+    dest_vol.scales.append(src_vol.scale)
+    dest_vol.mip = src_vol.scale["resolution"]
+    dest_vol.commit_info()
 
   if dest_voxel_offset is not None:
     dest_vol.scale["voxel_offset"] = dest_voxel_offset

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -423,7 +423,8 @@ def create_image_shard_transfer_tasks(
   agglomerate: bool = False, 
   timestamp: int = None,
   memory_target: int = MEMORY_TARGET,
-  clean_info: bool = False
+  clean_info: bool = False,
+  encoding_level: Optional[int] = None,
 ):
   src_vol = CloudVolume(src_layer_path, mip=mip)
 
@@ -492,6 +493,7 @@ def create_image_shard_transfer_tasks(
         mip=mip,
         agglomerate=agglomerate,
         timestamp=timestamp,
+        encoding_level=encoding_level,
       )
 
     def on_finish(self):
@@ -505,6 +507,7 @@ def create_image_shard_transfer_tasks(
           "translate": list(map(int, translate)),
           "bounds": [bounds.minpt.tolist(), bounds.maxpt.tolist()],
           "mip": mip,
+          "encoding_level": encoding_level,
         },
         "by": operator_contact(),
         "date": strftime("%Y-%m-%d %H:%M %Z"),
@@ -668,6 +671,7 @@ def create_transfer_tasks(
   clean_info:bool = False, 
   no_src_update:bool = False, 
   bounds_mip:int = 0,
+  encoding_level:Optional[int] = None,
 ) -> Iterator:
   """
   Transfer data to a new data layer. You can use this operation
@@ -703,6 +707,10 @@ def create_transfer_tasks(
     image type-specific first stage of compression and the "compress" flag as the data
     agnostic second stage compressor. For example, compressed_segmentation and gzip work
     well together, but not jpeg and gzip.
+  encoding_level: Some encoding schemes (png,jpeg,fpzip) offer a simple scalar knob
+    to control encoding quality. This number corresponds to png level, jpeg quality,
+    and fpzip precision. Other schemes might require more complex inputs and may
+    require info file modifications.
   factor: (overrides axis) can manually specify what each downsampling round is
     supposed to do: e.g. (2,2,1), (2,2,2), etc
   fill_missing: Treat missing image tiles as zeroed for both src and dest.
@@ -829,6 +837,7 @@ def create_transfer_tasks(
         compress=compress,
         factor=factor,
         sparse=sparse,
+        encoding_level=encoding_level,
       )
 
     def on_finish(self):
@@ -855,6 +864,7 @@ def create_transfer_tasks(
           'memory_target': memory_target,
           'factor': (tuple(factor) if factor else None),
           'sparse': bool(sparse),
+          'encoding_level': encoding_level,
         },
         'by': operator_contact(),
         'date': strftime('%Y-%m-%d %H:%M %Z'),

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -33,7 +33,7 @@ from igneous.types import ShapeType
 
 from .common import (
   operator_contact, FinelyDividedTaskIterator, 
-  get_bounds, num_tasks, prod
+  get_bounds, num_tasks, prod, set_encoding
 )
 
 __all__  = [
@@ -454,10 +454,8 @@ def create_image_shard_transfer_tasks(
   else:
     translate = Vec(*translate) // src_vol.downsample_ratio
 
-  if encoding is not None:
-    dest_vol.info['scales'][mip]['encoding'] = encoding
-    if encoding == 'compressed_segmentation' and 'compressed_segmentation_block_size' not in dest_vol.info['scales'][mip]:
-      dest_vol.info['scales'][mip]['compressed_segmentation_block_size'] = (8,8,8)
+  set_encoding(dest_vol, mip, encoding, encoding_level)
+
   dest_vol.info['scales'] = dest_vol.info['scales'][:mip+1]
   dest_vol.info['scales'][mip]['chunk_sizes'] = [ chunk_size.tolist() ]
 
@@ -779,10 +777,7 @@ def create_transfer_tasks(
   else:
     translate = Vec(*translate) // src_vol.downsample_ratio
 
-  if encoding is not None:
-    dest_vol.info['scales'][mip]['encoding'] = encoding
-    if encoding == 'compressed_segmentation' and 'compressed_segmentation_block_size' not in dest_vol.info['scales'][mip]:
-      dest_vol.info['scales'][mip]['compressed_segmentation_block_size'] = (8,8,8)
+  set_encoding(dest_vol, mip, encoding, encoding_level)
   dest_vol.info['scales'] = dest_vol.info['scales'][:mip+1]
   dest_vol.info['scales'][mip]['chunk_sizes'] = [ chunk_size.tolist() ]
 

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -376,7 +376,8 @@ def TransferTask(
   agglomerate=False,
   timestamp=None,
   compress='gzip',
-  factor=None
+  factor=None,
+  encoding_level=None,
 ):
   """
   Transfer an image to a new location while enabling
@@ -400,7 +401,8 @@ def TransferTask(
   dest_cv = CloudVolume(
     dest_path, fill_missing=fill_missing,
     mip=mip, delete_black_uploads=delete_black_uploads,
-    background_color=background_color, compress=compress
+    background_color=background_color, compress=compress,
+    encoding_level=encoding_level,
   )
 
   dst_bbox = Bbox(offset, shape + offset)
@@ -478,6 +480,7 @@ def ImageShardTransferTask(
   translate: ShapeType = (0, 0, 0),
   agglomerate: bool = False,
   timestamp: Optional[int] = None,
+  encoding_level: Optional[int] = None,
 ):
   """
   Generates a sharded image volume from
@@ -504,7 +507,8 @@ def ImageShardTransferTask(
     dst_path,
     fill_missing=fill_missing,
     mip=mip,
-    compress=None
+    compress=None,
+    encoding_level=encoding_level,
   )
 
   dst_bbox = Bbox(offset, offset + shape)

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -377,7 +377,6 @@ def TransferTask(
   timestamp=None,
   compress='gzip',
   factor=None,
-  encoding_level=None,
 ):
   """
   Transfer an image to a new location while enabling
@@ -402,7 +401,6 @@ def TransferTask(
     dest_path, fill_missing=fill_missing,
     mip=mip, delete_black_uploads=delete_black_uploads,
     background_color=background_color, compress=compress,
-    encoding_level=encoding_level,
   )
 
   dst_bbox = Bbox(offset, shape + offset)
@@ -480,7 +478,6 @@ def ImageShardTransferTask(
   translate: ShapeType = (0, 0, 0),
   agglomerate: bool = False,
   timestamp: Optional[int] = None,
-  encoding_level: Optional[int] = None,
 ):
   """
   Generates a sharded image volume from
@@ -508,7 +505,6 @@ def ImageShardTransferTask(
     fill_missing=fill_missing,
     mip=mip,
     compress=None,
-    encoding_level=encoding_level,
   )
 
   dst_bbox = Bbox(offset, offset + shape)

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -212,6 +212,7 @@ def downsample(
 @click.option('--memory', default=3.5e9, type=int, help="Task memory limit in bytes. Task shape will be chosen to fit and maximize downsamples.", show_default=True)
 @click.option('--max-mips', default=5, help="Maximum number of additional pyramid levels.", show_default=True)
 @click.option('--encoding', default="raw", help="Which image encoding to use. Options: [all] raw, png; [images] jpeg; [segmentations] cseg, compresso; [floats] fpzip, kempressed", show_default=True)
+@click.option('--encoding-level', default=None, help="For some encodings (png level,jpeg quality,fpzip precision) a simple scalar value can adjust the compression efficiency.", show_default=True)
 @click.option('--sparse', is_flag=True, default=False, help="Don't count black pixels in mode or average calculations. For images, eliminates edge ghosting in 2x2x2 downsample. For segmentation, prevents small objects from disappearing at high mip levels.")
 @click.option('--shape', type=Tuple3(), default=(2048, 2048, 64), help="(overrides --memory) Set the task shape in voxels. This also determines how many downsamples you get. e.g. 2048,2048,64")
 @click.option('--chunk-size', type=Tuple3(), default=None, help="Chunk size of destination layer. e.g. 128,128,64")
@@ -228,7 +229,7 @@ def xfer(
 	ctx, src, dest, queue, translate, 
   downsample, mip, fill_missing, 
   memory, max_mips, shape, sparse, 
-  encoding, chunk_size, compress, 
+  encoding, encoding_level, chunk_size, compress,
   volumetric, delete_bg, bg_color, sharded,
   dest_voxel_offset, clean_info, no_src_update
 ):
@@ -265,7 +266,8 @@ def xfer(
       src, dest,
       chunk_size=chunk_size, fill_missing=fill_missing, mip=mip, 
       dest_voxel_offset=dest_voxel_offset, translate=translate, 
-      encoding=encoding, memory_target=memory, clean_info=clean_info
+      encoding=encoding, memory_target=memory, clean_info=clean_info,
+      encoding_level=encoding_level,
     )
   else:
     tasks = tc.create_transfer_tasks(
@@ -276,7 +278,8 @@ def xfer(
       delete_black_uploads=delete_bg, background_color=bg_color,
       compress=compress, factor=factor, sparse=sparse,
       memory_target=memory, max_mips=max_mips, 
-      clean_info=clean_info, no_src_update=no_src_update
+      clean_info=clean_info, no_src_update=no_src_update,
+      encoding_level=encoding_level,
     )
 
   parallel = int(ctx.obj.get("parallel", 1))


### PR DESCRIPTION
Adds `--encoding-level` to `igneous image xfer` which allows you to control jpeg quality, png level, and fpzip precision. This gets added to the info file as `jpeg_quality`, `png_level`, and `fpzip_precision` on the indicated scale. All other scales will continue to use defaults unless the correct parameter is present.