### PR TITLE
Reduce read requests when creating sharded skeletons and meshes

### DIFF
--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -687,7 +687,8 @@ def create_sharded_multires_mesh_tasks(
   minishard_index_encoding="gzip", 
   mesh_dir:Optional[str] = None, 
   spatial_index_db:Optional[str] = None,
-  frag_path = None,
+  frag_path:Optional[str] = None,
+  cache:Optional[bool] = False,
   min_chunk_size:Tuple[int,int,int] = (256,256,256),
   max_labels_per_shard:Optional[int] = None,
 ) -> Iterator[MultiResShardedMeshMergeTask]: 
@@ -773,6 +774,7 @@ def create_sharded_multires_mesh_tasks(
       num_lod=num_lod,
       mesh_dir=mesh_dir, 
       frag_path=frag_path,
+      cache=cache,
       spatial_index_db=spatial_index_db,
       draco_compression_level=draco_compression_level,
       min_chunk_size=min_chunk_size,

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -160,7 +160,7 @@ def create_meshing_tasks(
     simplification=True, max_simplification_error=40,
     mesh_dir=None, cdn_cache=False, dust_threshold=None,
     object_ids=None, progress=False, fill_missing=False,
-    encoding='precomputed', spatial_index=True, sharded=False,
+    encoding='precomputed', spatial_index=True, frag_path=None, sharded=False,
     compress='gzip', closed_dataset_edges=True, dust_global=False
   ):
   shape = Vec(*shape)
@@ -205,6 +205,7 @@ def create_meshing_tasks(
         fill_missing=fill_missing,
         encoding=encoding,
         spatial_index=spatial_index,
+        frag_path=frag_path,
         sharded=sharded,
         compress=compress,
         closed_dataset_edges=closed_dataset_edges,
@@ -226,6 +227,7 @@ def create_meshing_tasks(
           'encoding': encoding,
           'object_ids': object_ids,
           'spatial_index': spatial_index,
+          'frag_path': frag_path,
           'sharded': sharded,
           'compress': compress,
           'closed_dataset_edges': closed_dataset_edges,
@@ -685,6 +687,7 @@ def create_sharded_multires_mesh_tasks(
   minishard_index_encoding="gzip", 
   mesh_dir:Optional[str] = None, 
   spatial_index_db:Optional[str] = None,
+  frag_path = None,
   min_chunk_size:Tuple[int,int,int] = (256,256,256),
   max_labels_per_shard:Optional[int] = None,
 ) -> Iterator[MultiResShardedMeshMergeTask]: 
@@ -755,6 +758,7 @@ def create_sharded_multires_mesh_tasks(
       'minishard_bits': minishard_bits, 
       'shard_bits': shard_bits,
       'mesh_dir': mesh_dir,
+      'frag_path': frag_path,
       'draco_compression_level': draco_compression_level,
       'min_chunk_size': min_chunk_size,
     },
@@ -768,6 +772,7 @@ def create_sharded_multires_mesh_tasks(
       cloudpath, shard_no, 
       num_lod=num_lod,
       mesh_dir=mesh_dir, 
+      frag_path=frag_path,
       spatial_index_db=spatial_index_db,
       draco_compression_level=draco_compression_level,
       min_chunk_size=min_chunk_size,

--- a/igneous/task_creation/skeleton.py
+++ b/igneous/task_creation/skeleton.py
@@ -47,7 +47,7 @@ def create_skeletonizing_tasks(
     fix_avocados=False, fill_holes=False,
     dust_threshold=1000, progress=False,
     parallel=1, fill_missing=False, 
-    sharded=False, spatial_index=True,
+    sharded=False, frag_path=None, spatial_index=True,
     synapses=None, num_synapses=None,
     dust_global=False
   ):
@@ -182,6 +182,7 @@ def create_skeletonizing_tasks(
         parallel=parallel,
         fill_missing=bool(fill_missing),
         sharded=bool(sharded),
+        frag_path=frag_path,
         spatial_index=bool(spatial_index),
         spatial_grid_shape=shape.clone(), # used for writing index filenames
         synapses=bbox_synapses,
@@ -298,6 +299,7 @@ def create_sharded_skeleton_merge_tasks(
   minishard_index_encoding:str = 'gzip', 
   data_encoding:str = 'gzip',
   max_cable_length:Optional[float] = None, 
+  frag_path:Optional[str] = None,
   spatial_index_db:Optional[str] = None,
   max_labels_per_shard:Optional[int] = None,
 ):
@@ -354,6 +356,7 @@ def create_sharded_skeleton_merge_tasks(
       'task': 'ShardedSkeletonMergeTask',
       'cloudpath': layer_path,
       'mip': cv.skeleton.meta.mip,
+      'frag_path': frag_path,
       'dust_threshold': dust_threshold,
       'tick_threshold': tick_threshold,
       'max_cable_length': max_cable_length,
@@ -372,6 +375,7 @@ def create_sharded_skeleton_merge_tasks(
       dust_threshold, tick_threshold,
       max_cable_length=max_cable_length,
       spatial_index_db=spatial_index_db,
+      frag_path=frag_path,
     )
     for shard_no in shard_labels.keys()
   ]

--- a/igneous/task_creation/skeleton.py
+++ b/igneous/task_creation/skeleton.py
@@ -300,6 +300,7 @@ def create_sharded_skeleton_merge_tasks(
   data_encoding:str = 'gzip',
   max_cable_length:Optional[float] = None, 
   frag_path:Optional[str] = None,
+  cache:Optional[bool] = False,
   spatial_index_db:Optional[str] = None,
   max_labels_per_shard:Optional[int] = None,
 ):
@@ -376,6 +377,7 @@ def create_sharded_skeleton_merge_tasks(
       max_cable_length=max_cable_length,
       spatial_index_db=spatial_index_db,
       frag_path=frag_path,
+      cache=cache,
     )
     for shard_no in shard_labels.keys()
   ]

--- a/igneous/tasks/mesh/mesh.py
+++ b/igneous/tasks/mesh/mesh.py
@@ -101,6 +101,7 @@ class MeshTask(RegisteredTask):
       'max_simplification_error': kwargs.get('max_simplification_error', 40),
       'simplification_factor': kwargs.get('simplification_factor', 100),
       'mesh_dir': kwargs.get('mesh_dir', None),
+      'frag_path': kwargs.get('frag_path', None),
       'mip': kwargs.get('mip', 0),
       'object_ids': kwargs.get('object_ids', None),
       'parallel_download': kwargs.get('parallel_download', 1),
@@ -315,7 +316,8 @@ class MeshTask(RegisteredTask):
       self._upload_spatial_index(self._bounds, bounding_boxes)
 
   def _upload_batch(self, meshes, bbox):
-    cf = CloudFiles(self.layer_path, progress=self.options['progress'])
+    frag_path = self.options['frag_path'] or self.layer_path
+    cf = CloudFiles(frag_path, progress=self.options['progress'])
 
     mbuf = MapBuffer(meshes, compress="br")
 

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -198,7 +198,7 @@ def MultiResShardedMeshMergeTask(
   min_chunk_size:Tuple[int,int,int] = (128,128,128),
   progress:bool = False
 ):
-  cv = CloudVolume(cloudpath, spatial_index_db=spatial_index_db)
+  cv = CloudVolume(cloudpath, spatial_index_db=spatial_index_db, cache=True)
   cv.mip = cv.mesh.meta.mip
   if mesh_dir is None and 'mesh' in cv.info:
     mesh_dir = cv.info['mesh']

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 
 from cloudfiles import CloudFiles, CloudFile
 
-from cloudvolume import CloudVolume, Mesh, view
+from cloudvolume import CloudVolume, Mesh, view, paths
 from cloudvolume.lib import Vec, Bbox, jsonify, sip, toiter, first
 from cloudvolume.datasource.precomputed.mesh.multilod \
   import MultiLevelPrecomputedMeshManifest, to_stored_model_space
@@ -193,6 +193,7 @@ def MultiResShardedMeshMergeTask(
   shard_no:str,
   draco_compression_level:int = 1,
   mesh_dir:Optional[str] = None,
+  frag_path:Optional[str] = None,
   num_lod:int = 1,
   spatial_index_db:Optional[str] = None,
   min_chunk_size:Tuple[int,int,int] = (128,128,128),
@@ -212,7 +213,7 @@ def MultiResShardedMeshMergeTask(
   labels = set(locations.keys())
   del locations
   meshes = collect_mesh_fragments(
-    cv, labels, filenames, mesh_dir, progress
+    cv, labels, filenames, mesh_dir, frag_path, progress
   )
   del filenames
 
@@ -372,6 +373,7 @@ def collect_mesh_fragments(
   labels:List[int], 
   filenames:List[str], 
   mesh_dir:str, 
+  frag_path:Optional[str],
   progress:bool = False
 ) -> Dict[int, List[Mesh]]:
   dirfn = lambda loc: cv.meta.join(mesh_dir, loc)
@@ -405,20 +407,25 @@ def collect_mesh_fragments(
 
     return filename
 
+  frag_prefix = frag_path or cv.cloudpath
+  local_input = False
+  if paths.extract(frag_prefix).protocol == "file":
+     local_input = True
+     frag_prefix = frag_prefix.replace("file://", "", 1)
+
   for filenames_block in tqdm(blocks, desc="Filename Block", total=n_blocks, disable=(not progress)):
-    if cv.meta.path.protocol == "file":
+    if local_input:
       all_files = {}
-      prefix = cv.cloudpath.replace("file://", "")
       for filename in filenames_block:
-        all_files[filename] = open(os.path.join(prefix, filename), "rb")
+        all_files[filename] = open(os.path.join(frag_prefix, filename), "rb")
 
       for item in tqdm(all_files.items(), desc="Scanning Fragments", disable=(not progress)):
         process_shardfile(item)
     else:
-      all_files = { 
-        filename: CloudFile(cv.meta.join(cv.cloudpath, filename), cache_meta=True) 
-        for filename in filenames_block 
-      } 
+      all_files = {
+        filename: CloudFile(cv.meta.join(frag_prefix, filename), cache_meta=True)
+        for filename in filenames_block
+      }
       with ThreadPoolExecutor(max_workers=block_size) as executor:
         for filename in executor.map(process_shardfile, all_files.items()):
           pass

--- a/igneous/tasks/mesh/multires.py
+++ b/igneous/tasks/mesh/multires.py
@@ -194,12 +194,13 @@ def MultiResShardedMeshMergeTask(
   draco_compression_level:int = 1,
   mesh_dir:Optional[str] = None,
   frag_path:Optional[str] = None,
+  cache:Optional[bool] = False,
   num_lod:int = 1,
   spatial_index_db:Optional[str] = None,
   min_chunk_size:Tuple[int,int,int] = (128,128,128),
   progress:bool = False
 ):
-  cv = CloudVolume(cloudpath, spatial_index_db=spatial_index_db, cache=True)
+  cv = CloudVolume(cloudpath, spatial_index_db=spatial_index_db, cache=cache)
   cv.mip = cv.mesh.meta.mip
   if mesh_dir is None and 'mesh' in cv.info:
     mesh_dir = cv.info['mesh']

--- a/igneous/tasks/skeleton.py
+++ b/igneous/tasks/skeleton.py
@@ -372,7 +372,8 @@ class ShardedSkeletonMergeTask(RegisteredTask):
     cv = CloudVolume(
       self.cloudpath, 
       progress=self.progress,
-      spatial_index_db=self.spatial_index_db
+      spatial_index_db=self.spatial_index_db,
+      cache=True
     )
 
     # This looks messy because we are trying to avoid retaining

--- a/igneous/tasks/skeleton.py
+++ b/igneous/tasks/skeleton.py
@@ -358,7 +358,7 @@ class UnshardedSkeletonMergeTask(RegisteredTask):
 class ShardedSkeletonMergeTask(RegisteredTask):
   def __init__(
     self, cloudpath, shard_no, 
-    dust_threshold=4000, tick_threshold=6000, frag_path=None,
+    dust_threshold=4000, tick_threshold=6000, frag_path=None, cache=False,
     spatial_index_db=None, max_cable_length=None
   ):
     super(ShardedSkeletonMergeTask, self).__init__(
@@ -376,7 +376,7 @@ class ShardedSkeletonMergeTask(RegisteredTask):
       self.cloudpath, 
       progress=self.progress,
       spatial_index_db=self.spatial_index_db,
-      cache=True
+      cache=self.cache
     )
 
     # This looks messy because we are trying to avoid retaining


### PR DESCRIPTION
This PR makes two changes to reduce read api calls when created sharded formats:
1. Cache spatial_index files. Because all the spatial_index are used by each skeleton/mesh merge tasks, the total reads goes quadratically with the volume (total number of spatial_index files x total number of tasks). Cache it makes the growth linear.
2. Optionally save the intermediary *.frag files to a separate location specified by frag_path. To create sharded format, each segment must be read from frag files at least once. Save and read them from a shared nfs volume reduces the read requests significantly.