### PR TITLE
skeletonization when resolution is non-integer value

### DIFF
--- a/igneous/tasks/skeleton.py
+++ b/igneous/tasks/skeleton.py
@@ -344,7 +344,8 @@ class UnshardedSkeletonMergeTask(RegisteredTask):
       return cropped
     
     for i in range(len(skeletons)):
-      bbx = bbxs[i] 
+      bbx = bbxs[i]
+      bbx = bbx.astype(self.vol.resolution.dtype) 
       bbx.minpt += self.crop * self.vol.resolution
       bbx.maxpt -= self.crop * self.vol.resolution
 


### PR DESCRIPTION
Part 2 of skeletonization, merging, failed when the resolution of the data is float. Fixed the issue and tested on one of our data.