### PR TITLE
feat(SkeletonTask): compute cross sectional area

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,9 @@ Of note: Meshing is a memory intensive operation. The underlying zmesh library h
 Igneous provides the engine for performing out-of-core skeletonization of labeled images. 
 The in-core part of the algorithm is provided by the [Kimimaro](https://github.com/seung-lab/kimimaro) library.  
 
-The strategy is to apply Kimimaro mass skeletonization to 1 voxel overlapping chunks of the segmentation and then fuse them in a second pass. Both sharded and unsharded formats are supported. For very large datasets, note that sharded runs better on a local cluster as it can make use of `mmap`.
+The strategy is to apply Kimimaro mass skeletonization to 1 voxel overlapping chunks of the segmentation and then fuse them in a second pass. Both sharded and unsharded formats are supported. For very large datasets, note that sharded runs better on a local cluster as it can make use of `mmap`.  
+
+We also support computing the cross sectional area at each vertex, but be aware that this will add significant time to the computation (currently many hours for a densely labeled task). This is practical for sparse labeling though. This should be improved substantially in the future.
 
 #### CLI Skeletonization
 
@@ -513,6 +515,8 @@ tasks = tc.create_skeletonizing_tasks(
     parallel=1, # Number of parallel processes to use (more useful locally)
     spatial_index=True, # generate a spatial index for querying skeletons by bounding box
     sharded=False, # generate intermediate shard fragments for later processing into sharded format
+    cross_sectional_area=False, # Compute the cross sectional area for each vertex.
+    cross_sectional_area_smoothing_window=5, # Rolling average of vertices.
   )
 
 # Second Pass: Fuse Skeletons (unsharded version)

--- a/igneous/tasks/skeleton.py
+++ b/igneous/tasks/skeleton.py
@@ -134,11 +134,11 @@ class SkeletonTask(RegisteredTask):
       extra_targets_after=extra_targets_after.keys(),
     )
 
-    if cross_sectional_area:
+    if self.cross_sectional_area:
       skeletons = kimimaro.cross_sectional_area(
         all_labels, skeletons,
         anisotropy=vol.resolution,
-        smoothing_window=cross_sectional_area_smoothing_window,
+        smoothing_window=self.cross_sectional_area_smoothing_window,
         progress=self.progress,
       )
 

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -1164,13 +1164,15 @@ def skeletongroup():
 @click.option('--max-paths', default=None, help="Abort skeletonizing an object after this many paths have been traced.", type=float)
 @click.option('--sharded', is_flag=True, default=False, help="Generate shard fragments instead of outputing skeleton fragments.", show_default=True)
 @click.option('--labels', type=TupleN(), default=None, help="Skeletonize only this comma separated list of labels.", show_default=True)
+@click.option('--cross-section', type=int, default=0, help="Compute the cross sectional area for each skeleton vertex. May add substantial computation time. Integer value is the normal vector rolling average smoothing window over vertices. 0 means off.", show_default=True)
 @click.pass_context
 def skeleton_forge(
   ctx, path, queue, mip, shape, 
   fill_missing, dust_threshold, dust_global, spatial_index,
   fix_branching, fix_borders, fix_avocados, 
   fill_holes, scale, const, soma_detect, soma_accept,
-  soma_scale, soma_const, max_paths, sharded, labels
+  soma_scale, soma_const, max_paths, sharded, labels,
+  cross_section,
 ):
   """
   (1) Synthesize skeletons from segmentation cutouts.
@@ -1213,6 +1215,8 @@ def skeleton_forge(
     parallel=1, fill_missing=fill_missing, 
     sharded=sharded, spatial_index=spatial_index,
     dust_global=dust_global, object_ids=labels,
+    cross_sectional_area=(cross_section > 0),
+    cross_sectional_area_smoothing_window=int(cross_section),
   )
 
   enqueue_tasks(ctx, queue, tasks)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 click>=6.7
 cloud-files>=4.11.0
-cloud-volume>=8.11.1
+cloud-volume>=8.29.0
 crackle-codec
 connected-components-3d>=3.10.1
 DracoPy>=1.0.1,<2.0.0
 fastremap>=1.13.2
 google-cloud-logging
-kimimaro>=0.5.0
-mapbuffer>=0.6.0
+kimimaro>=3.4.0
+mapbuffer>=0.7.1
 networkx
 numpy>=1.14.2
 pathos

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ shard-computer
 tinybrain
 task-queue>=2.4.0
 tqdm
-zmesh>=1.4,<2.0
 trimesh[easy]
+xs3d>=0.2.0
+zmesh>=1.4,<2.0


### PR DESCRIPTION
Adds `cross_sectional_area=True` and `cross_sectional_area_smoothing_window=1` to `SkeletonTask`.

As of this writing, the xs3d module kimimaro uses is too slow to do a dense calculation (think: 8+ hrs per a task) but is fast enough to do it for sparse neurons (thousands of times less work).