### PR TITLE
make mesh_dir behavior consistent across create_meshing_tasks and create_mesh_manifest_tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ tasks = create_meshing_tasks(             # First Pass
 tasks = create_mesh_manifest_tasks(layer_path, magnitude=3) # Second Pass
 ```
 
-The parameters above are mostly self explainatory, but the magnitude parameter of `create_mesh_manifest_tasks` is a bit odd. What a MeshManifestTask does is iterate through a proportion of the files defined by a filename prefix. `magnitude` splits up the work by 
+The parameters above are mostly self explanatory, but the magnitude parameter of `create_mesh_manifest_tasks` is a bit odd. What a MeshManifestTask does is iterate through a proportion of the files defined by a filename prefix. `magnitude` splits up the work by
 an additional 10^magnitude. A high magnitude (3-5+) is appropriate for horizontal scaling workloads while small magnitudes 
 (1-2) are more suited for small volumes locally processed since there is overhead introduced by splitting up the work.  
 
@@ -515,8 +515,6 @@ tasks = tc.create_skeletonizing_tasks(
     dust_threshold=1000, # Don't skeletonize below this physical distance
     progress=False, # Show a progress bar
     parallel=1, # Number of parallel processes to use (more useful locally)
-    spatial_index=True, # generate a spatial index for querying skeletons by bounding box
-    sharded=False, # generate intermediate shard fragments for later processing into sharded format
     cross_sectional_area=False, # Compute the cross sectional area for each vertex.
     cross_sectional_area_smoothing_window=5, # Rolling average of vertices.
   )

--- a/igneous/task_creation/mesh.py
+++ b/igneous/task_creation/mesh.py
@@ -168,7 +168,10 @@ def create_meshing_tasks(
   vol = CloudVolume(layer_path, mip)
 
   if mesh_dir is None:
-    mesh_dir = 'mesh_mip_{}_err_{}'.format(mip, max_simplification_error)
+    if 'mesh' in vol.info:
+      mesh_dir = vol.info['mesh']
+    else:
+      mesh_dir = 'mesh_mip_{}_err_{}'.format(mip, max_simplification_error)
 
   if not 'mesh' in vol.info:
     vol.info['mesh'] = mesh_dir

--- a/igneous/task_creation/skeleton.py
+++ b/igneous/task_creation/skeleton.py
@@ -48,8 +48,9 @@ def bounds_from_mesh(
   """Estimate the bounding box of a label from its mesh if available."""
   bbxes = []
   for label in labels:
-    mesh = vol.mesh.get(labels)[label]
-    if mesh is None:
+    try:
+      mesh = vol.mesh.get(label)
+    except ValueError:
       raise ValueError(f"Mesh {label} is not available.")
 
     bounds = Bbox.from_points(mesh.vertices // vol.resolution)


### PR DESCRIPTION
Currently, running the example code with default arguments `mesh_dir=None`
- `create_meshing_tasks` leads to the creation of `LAYER/mesh_mip_0_err_40` (ignoring the value of `vol.info['mesh']`)
- `create_mesh_manifest_tasks` on the other hand tries to read/write from `LAYER/{vol.info["mesh"]}` https://github.com/seung-lab/igneous/blob/5f9f18f7f84e547cbf6f15c9bcd5b959581d0bed/igneous/task_creation/mesh.py#L63 https://github.com/seung-lab/igneous/blob/5f9f18f7f84e547cbf6f15c9bcd5b959581d0bed/igneous/tasks/mesh/mesh.py#L576

This and some minor `README.md` improvements.