### PR TITLE
feat: multi-mip sharded downsampling

### DIFF
--- a/igneous/__init__.py
+++ b/igneous/__init__.py
@@ -1,4 +1,4 @@
 from zmesh import Mesher
-from taskqueue import MockTaskQueue, TaskQueue, RegisteredTask
+from taskqueue import MockTaskQueue, LocalTaskQueue, TaskQueue, RegisteredTask
 from .tasks import *
 from cloudvolume import CloudVolume, Storage, EmptyVolumeException

--- a/igneous/downsample_scales.py
+++ b/igneous/downsample_scales.py
@@ -243,8 +243,8 @@ def create_downsample_scales(
   vol.commit_info()
   return vol
 
-def add_scale(
-  layer_path, mip,
+def add_scales(
+  layer_path, mip, num_mips,
   preserve_chunk_size=True, chunk_size=None,
   encoding=None, factor=None
 ):
@@ -253,23 +253,27 @@ def add_scale(
   if factor is None:
     factor = (2,2,1)
 
-  new_resolution = vol.resolution * Vec(*factor)
-  vol.meta.add_resolution(
-    new_resolution, encoding=encoding, chunk_size=chunk_size
-  )
+  for i in range(num_mips):
+    new_resolution = vol.resolution * Vec(*factor)
+    vol.meta.add_resolution(
+      new_resolution, encoding=encoding, chunk_size=chunk_size
+    )
 
-  if chunk_size is None:
-    if preserve_chunk_size:
-      chunk_size = vol.scales[mip]['chunk_sizes']
+    if chunk_size is None:
+      if preserve_chunk_size:
+        chunk_size_ds = vol.scales[mip]['chunk_sizes']
+      else:
+        chunk_size_ds = vol.scales[mip + 1]['chunk_sizes']
     else:
-      chunk_size = vol.scales[mip + 1]['chunk_sizes']
-  else:
-    chunk_size = [ chunk_size ]
+      chunk_size_ds = [ chunk_size ]
 
-  if encoding is None:
-    encoding = vol.scales[mip]['encoding']
+    if encoding is None:
+      encoding = vol.scales[mip]['encoding']
 
-  vol.scales[mip + 1]['chunk_sizes'] = chunk_size
+    vol.scales[mip + 1]['chunk_sizes'] = chunk_size_ds
+
+    mip += 1
+    vol.mip = mip
 
   return vol
 

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -637,7 +637,7 @@ def create_image_shard_downsample_tasks(
   Downsamples an existing image layer that may be
   sharded or unsharded to create a sharded layer.
   
-  Only 2x2x1 downsamples are supported for now.
+  Only 2x2x1 and 2x2x2 downsamples are supported for now.
   """
   if num_mips is None:
     num_mips = 3
@@ -677,7 +677,7 @@ def create_image_shard_downsample_tasks(
   shape = image_shard_shape_from_spec(
     sharding, cv.volume_size, cv.chunk_size
   )
-  shape = Vec(*shape) * factor
+  shape = Vec(*shape) * (np.array(factor) ** num_mips)
 
   cv.mip = mip
   bounds = get_bounds(

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -687,10 +687,13 @@ def create_image_shard_downsample_tasks(
   cv.commit_info()
 
   sharding = cv.info["scales"][mip + 1]["sharding"]
-  shape = image_shard_shape_from_spec(
-    sharding, cv.volume_size, cv.chunk_size
+  base_shape = image_shard_shape_from_spec(
+    sharding, 
+    cv.meta.volume_size(mip + 1), 
+    cv.meta.chunk_size(mip + 1),
   )
-  shape = Vec(*shape) * (np.array(factor) ** num_mips)
+
+  shape = Vec(*base_shape) * (np.array(factor) ** num_mips)
 
   cv.mip = mip
   bounds = get_bounds(

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -646,6 +646,13 @@ def create_image_shard_downsample_tasks(
   sharded or unsharded to create a sharded layer.
   
   Only 2x2x1 and 2x2x2 downsamples are supported for now.
+
+  Note that doing > 1 mip level at a time will use significantly
+  more memory unless your data is compressible.
+
+  Lossy compressed images with num_mips > 1 will have the top mip
+  level be losslessly compressed to enable reliably building 
+  additional downsamples on top of it.
   """
   if num_mips is None:
     num_mips = 3

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -639,6 +639,7 @@ def create_image_shard_downsample_tasks(
   encoding_effort:Optional[int] = None,
   method=DownsampleMethods.AUTO, 
   num_mips:Optional[int] = None,
+  truncate_scales:bool = True,
 ) -> Iterator:
   """
   Downsamples an existing image layer that may be
@@ -648,6 +649,11 @@ def create_image_shard_downsample_tasks(
   """
   if num_mips is None:
     num_mips = 3
+
+  cv = CloudVolume(cloudpath)
+  if truncate_scales:
+    cv.scales = cv.scales[:mip+1]
+    cv.commit_info()
 
   cv = downsample_scales.add_scales(
     cloudpath, mip, num_mips, 

--- a/igneous/task_creation/image.py
+++ b/igneous/task_creation/image.py
@@ -623,16 +623,23 @@ def create_image_shard_transfer_tasks(
   return ImageShardTransferTaskIterator(bounds, shape)
 
 def create_image_shard_downsample_tasks(
-  cloudpath, mip=0, fill_missing=False, 
-  sparse=False, chunk_size=None,
-  encoding=None, memory_target=MEMORY_TARGET,
-  agglomerate=False, timestamp=None,
-  factor=(2,2,1), bounds=None, bounds_mip=0,
+  cloudpath:str,
+  mip:int = 0, 
+  fill_missing:bool = False, 
+  sparse:bool = False, 
+  chunk_size:Optional[tuple[int,int,int]] = None,
+  encoding:Optional[str] = None,
+  memory_target:int = MEMORY_TARGET,
+  agglomerate:bool = False, 
+  timestamp:Optional[int] = None,
+  factor:tuple[int,int,int] = (2,2,1), 
+  bounds:Optional[Bbox] = None, 
+  bounds_mip:int = 0,
   encoding_level:Optional[int] = None,
   encoding_effort:Optional[int] = None,
   method=DownsampleMethods.AUTO, 
   num_mips:Optional[int] = None,
-):
+) -> Iterator:
   """
   Downsamples an existing image layer that may be
   sharded or unsharded to create a sharded layer.

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -767,8 +767,10 @@ def ImageShardDownsampleTask(
             continue
 
           shard_z_bbox = zbox.clone()
-          shard_z_bbox.minpt[:2] //= (2 ** (i+1))
-          shard_z_bbox.maxpt[:2] //= (2 ** (i+1))
+          shard_z_bbox.minpt[:2] //= (factor[0] ** (i+1))
+          shard_z_bbox.maxpt[:2] //= (factor[1] ** (i+1))
+          shard_z_bbox.minpt[2] //= factor[2]
+          shard_z_bbox.maxpt[2] //= factor[2]
 
           shard_z_bbox.minpt += np.array([ xoff, yoff, 0 ])
           shard_z_bbox.maxpt = shard_z_bbox.minpt + np.array([ shard_shape[0], shard_shape[1], chunk_size.z ])

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -790,18 +790,18 @@ def ImageShardDownsampleTask(
 
   for i in range(num_mips):
     shard_shape = shard_shapefn(mip + i + 1)
-    for k, ((shard_x, shard_y), chunk_dict) in enumerate(output_shards_by_mip[i].items()):
+    for (shard_x, shard_y), chunk_dict in output_shards_by_mip[i].items():
       minpt = np.array([ shard_x * shard_shape[0], shard_y * shard_shape[0], wide_bbox.minpt.z ])
       shard_bbox = Bbox(minpt, minpt + shard_shape)
       shard_bbox += src_vol.meta.voxel_offset(mip + i + 1)
       (filename, shard) = src_vol.image.make_shard(
-        output_img, shape_bbox, (mip + i + 1), progress=False
+        chunk_dict, shape_bbox, (mip + i + 1), progress=False
       )
       basepath = src_vol.meta.join(
         src_vol.cloudpath, src_vol.meta.key(mip + i + 1)
       )
       CloudFiles(basepath).put(filename, shard)
-      output_shards_by_mip[k] = None # free RAM
+    output_shards_by_mip[i] = None # Free RAM
 
 @queueable
 def CountVoxelsTask(

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -744,10 +744,10 @@ def ImageShardDownsampleTask(
 
       num_x_shards = int(factor[0] ** (num_mips - i))
       num_y_shards = int(factor[1] ** (num_mips - i))
-      num_x_shards = int(min(num_x_shards, zbox.size().x // shard_shape[0]) // (2**i))
-      num_y_shards = int(min(num_y_shards, zbox.size().y // shard_shape[1]) // (2**i))
-      num_x_shards = int(min(num_x_shards, src_vol.meta.volume_size(mip+i+1).x // shard_shape[0]))
-      num_y_shards = int(min(num_y_shards, src_vol.meta.volume_size(mip+i+1).y // shard_shape[1]))
+      num_x_shards = int(min(num_x_shards, np.ceil(zbox.size().x / shard_shape[0])) // (2**i))
+      num_y_shards = int(min(num_y_shards, np.ceil(zbox.size().y / shard_shape[1])) // (2**i))
+      num_x_shards = int(min(num_x_shards, np.ceil(src_vol.meta.volume_size(mip+i).x / shard_shape[0])))
+      num_y_shards = int(min(num_y_shards, np.ceil(src_vol.meta.volume_size(mip+i).y / shard_shape[1])))
       num_x_shards = max(num_x_shards, 1)
       num_y_shards = max(num_y_shards, 1)
 

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -763,6 +763,9 @@ def ImageShardDownsampleTask(
             yoff:int(yoff+shard_shape[1])
           ]
 
+          if shard_z_cutout.size == 0:
+            continue
+
           shard_z_bbox = zbox.clone()
           shard_z_bbox.minpt[:2] //= (2 ** (i+1))
           shard_z_bbox.maxpt[:2] //= (2 ** (i+1))

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -677,6 +677,7 @@ def ImageShardDownsampleTask(
   timestamp: Optional[int] = None,
   factor: ShapeType = (2,2,1),
   method: int = DownsampleMethods.AUTO,
+  num_mips: int = 1,
 ):
   """
   Generate a single downsample level for a shard.
@@ -695,17 +696,28 @@ def ImageShardDownsampleTask(
   )
   chunk_size = src_vol.meta.chunk_size(mip)
 
+  full_shape = shape * (factor ** num_mips)
+
+  wide_bbox = Bbox(offset, offset + full_shape)
+  wide_bbox = Bbox.clamp(bbox, src_vol.meta.bounds(mip))
+  wide_bbox = wide_bbox.expand_to_chunk_size(
+    chunk_size, offset=src_vol.meta.voxel_offset(mip)
+  )
+
   bbox = Bbox(offset, offset + shape)
   bbox = Bbox.clamp(bbox, src_vol.meta.bounds(mip))
   bbox = bbox.expand_to_chunk_size(
     chunk_size, offset=src_vol.meta.voxel_offset(mip)
   )
 
-  shard_shape = igneous.shards.image_shard_shape_from_spec(
-    src_vol.scales[mip + 1]["sharding"], 
-    src_vol.meta.volume_size(mip + 1), 
-    src_vol.meta.chunk_size(mip + 1)
-  )
+  def shard_shapefn(mip):
+    return igneous.shards.image_shard_shape_from_spec(
+      src_vol.scales[mip]["sharding"], 
+      src_vol.meta.volume_size(mip), 
+      src_vol.meta.chunk_size(mip)
+    )    
+
+  shard_shape = shard_shapefn(mip + 1)
   upper_offset = offset // Vec(*factor)
   shape_bbox = Bbox(upper_offset, upper_offset + shard_shape)
   shape_bbox = shape_bbox.astype(np.int64)
@@ -721,38 +733,69 @@ def ImageShardDownsampleTask(
 
   shard_shape = list(shape_bbox.size3()) + [ 1 ]
 
-  output_img = np.zeros(shard_shape, dtype=src_vol.dtype, order="F")
-  nz = int(math.ceil(bbox.dz / (chunk_size.z * factor[2])))
+  output_shards_by_mip = []
+  for mip_i in range(mip + 1, mip + num_mips + 1):
+    output_shards = []
+    shard_shape = shard_shapefn(mip_i)
+    num_shards_per_mip = int((factor[0] * factor[1] * factor[2]) ** (num_mips - mip_i))
+    for i in range(num_shards_per_mip):
+      output_shards.append({})
+    output_shards_by_mip.append(output_shards)
+
+  nz = int(math.ceil(wide_bbox.dz / (chunk_size.z * factor[2])))
 
   dsfn = downsample_method_to_fn(method, sparse, src_vol)
 
-  zbox = bbox.clone()
-  z_thickness = chunk_size.z * factor[2]
-  zbox.maxpt.z = zbox.minpt.z + z_thickness
+  zbox = wide_bbox.clone()
+  zbox.maxpt.z = zbox.minpt.z + (chunk_size.z * factor[2])
   for z in range(nz):
     img = src_vol.download(
       zbox, agglomerate=agglomerate, timestamp=timestamp
     )
-    (ds_img,) = dsfn(img, factor, num_mips=1, sparse=sparse)
+    ds_imgs = dsfn(img, factor, num_mips=num_mips, sparse=sparse)
     # ds_img[slc] b/c sometimes the size round up in tinybrain
     # makes this too large by one voxel on an axis
     xlim, ylim = tuple(ds_img.shape[:2])
     zs = z * chunk_size.z
     ze = (z+1) * chunk_size.z
-    output_img[:xlim,:ylim,zs:ze] = ds_img
+    # output_img[:xlim,:ylim,zs:ze] = ds_img
+    for i in range(num_mips):
+      num_x_shards = int(factor[0] ** (num_mips - i))
+      num_y_shards = int(factor[1] ** (num_mips - i))
+      shard_shape = shard_shapefn(mip + i)
+      for shard_y in range(num_y_shards):
+        for shard_x in range(num_x_shards):
+          xoff = shard_x * shard_shape[0]
+          yoff = num_x_shards * shard_y * shard_shape[1]
+
+          shard_z_cutout = ds_imgs[i][xoff:xoff+shard_shape[0], yoff:yoff+shard_shape[1]]
+          shard_z_bbox = zbox.clone()
+
+          shard_z_bbox.minpt += np.array([ xoff, yoff, 0 ])
+          shard_z_bbox.maxpt = shard_z_bbox.minpt + np.array([ shard_shape[0], shard_shape[1], chunk_size.z ])
+
+          chunk_dict = cv.image.make_shard_chunks(shard_z_cutout, shard_z_bbox, mip + i + 1)
+
+          k = shard_x + num_x_shards * shard_y
+          output_shards_by_mip[i][k].update(chunk_dict)
 
     del img
-    del ds_img
-    zbox.minpt.z += z_thickness
-    zbox.maxpt.z += z_thickness
+    del ds_imgs
+    zbox.minpt.z += chunk_size.z
+    zbox.maxpt.z += chunk_size.z
 
-  (filename, shard) = src_vol.image.make_shard(
-    output_img, shape_bbox, (mip + 1), progress=False
-  )
-  basepath = src_vol.meta.join(
-    src_vol.cloudpath, src_vol.meta.key(mip + 1)
-  )
-  CloudFiles(basepath).put(filename, shard)
+  for i in range(num_mips):
+    shard_shape = shard_shapefn(mip + i)
+    for k, chunk_dict in enumerate(output_shards_by_mip[i]):
+      shard_bbox = ...
+      (filename, shard) = src_vol.image.make_shard(
+        output_img, shape_bbox, (mip + i + 1), progress=False
+      )
+      basepath = src_vol.meta.join(
+        src_vol.cloudpath, src_vol.meta.key(mip + 1)
+      )
+      CloudFiles(basepath).put(filename, shard)
+      output_shards_by_mip[k] = None # free RAM
 
 @queueable
 def CountVoxelsTask(

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -786,9 +786,14 @@ def ImageShardDownsampleTask(
     for (shard_x, shard_y), chunk_dict in output_shards_by_mip[i].items():
       minpt = np.array([ shard_x * shard_shape[0], shard_y * shard_shape[1], bbox.minpt.z ])
       shard_bbox = Bbox(minpt, minpt + shard_shape)
-      shard_bbox += src_vol.meta.voxel_offset(mip + i + 1)
+      offset = src_vol.meta.voxel_offset(mip + i + 1)
+      shard_bbox.minpt.x += offset[0]
+      shard_bbox.maxpt.x += offset[0]
+      shard_bbox.minpt.y += offset[1]
+      shard_bbox.maxpt.y += offset[1]
+
       (filename, shard) = src_vol.image.make_shard(
-        chunk_dict, shape_bbox, (mip + i + 1), progress=False
+        chunk_dict, shard_bbox, (mip + i + 1), progress=False
       )
       basepath = src_vol.meta.join(
         src_vol.cloudpath, src_vol.meta.key(mip + i + 1)

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -803,7 +803,7 @@ def ImageShardDownsampleTask(
       mip_offset = src_vol.meta.voxel_offset(mip + i + 1)
       shard_bbox.minpt += mip_offset
       shard_bbox.maxpt += mip_offset
-      
+
       (filename, shard) = src_vol.image.make_shard(
         chunk_dict, shard_bbox, (mip + i + 1), progress=False
       )

--- a/igneous/tasks/image/image.py
+++ b/igneous/tasks/image/image.py
@@ -776,7 +776,7 @@ def ImageShardDownsampleTask(
   for i in range(num_mips):
     shard_shape = shard_shapefn(mip + i + 1)
     for (shard_x, shard_y), chunk_dict in output_shards_by_mip[i].items():
-      minpt = np.array([ shard_x * shard_shape[0], shard_y * shard_shape[0], wide_bbox.minpt.z ])
+      minpt = np.array([ shard_x * shard_shape[0], shard_y * shard_shape[1], wide_bbox.minpt.z ])
       shard_bbox = Bbox(minpt, minpt + shard_shape)
       shard_bbox += src_vol.meta.voxel_offset(mip + i + 1)
       (filename, shard) = src_vol.image.make_shard(

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -274,11 +274,6 @@ def downsample(
   current top mip level of the pyramid. This builds it even taller
   (referred to as "superdownsampling").
   """
-  if sharded:
-    if num_mips and num_mips != 1:
-      print("igneous: sharded downsamples only support producing one mip at a time. num_mips set to 1")
-    num_mips = 1
-
   factor = (2,2,1)
   if volumetric:
   	factor = (2,2,2)
@@ -298,7 +293,7 @@ def downsample(
       encoding=encoding, memory_target=memory,
       factor=factor, bounds=bounds, bounds_mip=mip,
       encoding_level=encoding_level, method=method,
-      encoding_effort=encoding_effort,
+      encoding_effort=encoding_effort, num_mips=num_mips,
     )
   else:
     tasks = tc.create_downsampling_tasks(

--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -281,7 +281,7 @@ def downsample(
   if compress and compress.lower() in ("none", "false"):
     compress = False
 
-  if encoding and encoding.lower() in ("jpeg", "png", "fpzip", "zfpc"):
+  if encoding and encoding.lower() in ("jpeg", "jxl", "png", "fpzip", "zfpc"):
     compress = False
 
   bounds = compute_bounds(path, mip, xrange, yrange, zrange)

--- a/test/layer_harness.py
+++ b/test/layer_harness.py
@@ -14,6 +14,20 @@ def create_storage(layer_name='layer'):
     stor_path = os.path.join(layer_path, layer_name)
     return CloudFiles('file://' + stor_path)
 
+def create_connectomics(layer_name="layer"):
+    import crackle
+    arr = crackle.load("test/connectomics.npy.ckl.gz")
+    cv = CloudVolume.from_numpy(
+        arr, 
+        vol_path='file://' + layer_path + '/' + layer_name,
+        resolution=(16,16,40), 
+        voxel_offset=[0,0,0], 
+        chunk_size=(64,64,64), 
+        layer_type="segmentation", 
+        max_mip=0,
+    )
+    return cv, arr
+
 def create_layer(size, offset, layer_type="image", layer_name='layer', dtype=None):
 
     default = lambda dt: dtype or dt

--- a/test/test_ccl_tasks.py
+++ b/test/test_ccl_tasks.py
@@ -10,7 +10,7 @@ import numpy as np
 from cloudvolume import CloudVolume, EmptyVolumeException
 import cloudvolume.lib as lib
 from cloudfiles import CloudFiles
-from taskqueue import MockTaskQueue, TaskQueue
+from taskqueue import LocalTaskQueue, TaskQueue
 import tinybrain
 
 import igneous
@@ -49,7 +49,7 @@ def rmsrc():
 
 @pytest.fixture(scope="module")
 def tq():
-  return MockTaskQueue()
+  return LocalTaskQueue()
 
 @pytest.fixture(scope="function")
 def src_cv(checker_data):

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -568,7 +568,7 @@ def test_clahe_task():
         size=(1024,1024,129,1), offset=(0,0,0), 
         layer_type="image", layer_name='clahe'
     )
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
     tasks = tc.create_clahe_tasks(src_path, dest_path, shape=(512,512,64))
     tq.insert_all(tasks)
 

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -12,7 +12,7 @@ from cloudvolume import CloudVolume, EmptyVolumeException
 import cloudvolume.lib as lib
 from cloudfiles import CloudFiles
 import fastremap
-from taskqueue import MockTaskQueue, TaskQueue
+from taskqueue import LocalTaskQueue, TaskQueue
 import tinybrain
 
 from igneous import (
@@ -36,7 +36,7 @@ def test_downsample_no_offset(compression_method):
 
     cv.commit_info()
 
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
     tasks = create_downsampling_tasks(cf.cloudpath, mip=0, num_mips=4, compress=compression_method)
     tq.insert_all(tasks)
 
@@ -79,7 +79,7 @@ def test_downsample_no_offset_2x2x2():
 
     cv.commit_info()
 
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
     tasks = create_downsampling_tasks(
         cf.cloudpath, mip=0, num_mips=3, 
         compress=None, factor=(2,2,2)
@@ -120,7 +120,7 @@ def test_downsample_with_offset():
 
     cv.commit_info()
 
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
     tasks = create_downsampling_tasks(cf.cloudpath, mip=0, num_mips=3)
     tq.insert_all(tasks)
 
@@ -159,7 +159,7 @@ def test_downsample_w_missing():
 
     cv.commit_info()
 
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
 
     try:
         tasks = create_downsampling_tasks(cf.cloudpath, mip=0, num_mips=3, fill_missing=False)
@@ -167,7 +167,7 @@ def test_downsample_w_missing():
     except EmptyVolumeException:
         pass
 
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
 
     tasks = create_downsampling_tasks(cf.cloudpath, mip=0, num_mips=3, fill_missing=True)
     tq.insert_all(tasks)
@@ -192,7 +192,7 @@ def test_downsample_higher_mip():
     cv = CloudVolume(cf.cloudpath)
     cv.info['scales'] = cv.info['scales'][:1]
     
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
 
     cv.commit_info()
     tasks = create_downsampling_tasks(cf.cloudpath, mip=0, num_mips=2)
@@ -445,7 +445,7 @@ def test_luminance_levels_task():
         layer_type="image", layer_name='luminance_levels'
     )
 
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
     tasks = tc.create_luminance_levels_tasks( 
         layer_path=layer_path,
         coverage_factor=0.01, 
@@ -505,7 +505,7 @@ def test_contrast_normalization_task():
         size=(300,300,129,1), offset=(0,0,0), 
         layer_type="image", layer_name='contrast_normalization'
     )
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
     tasks = tc.create_luminance_levels_tasks( 
         layer_path=src_path,
         coverage_factor=0.01, 
@@ -546,7 +546,7 @@ def test_skeletonization_task(cross_sectional_area):
         vol_path=layer_path,
     )
 
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
     tasks = tc.create_skeletonizing_tasks(
         layer_path,
         mip=0,
@@ -579,7 +579,7 @@ def test_voxel_counting_task():
         vol_path=layer_path,
     )
 
-    tq = MockTaskQueue()
+    tq = LocalTaskQueue()
     tasks = tc.create_voxel_counting_tasks(layer_path, mip=0)
     tq.insert_all(tasks)
 

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -156,6 +156,51 @@ def test_downsample_no_offset_2x2x2():
     cv.mip = 3
     assert np.all(cv[slice64] == data_ds3[slice64])
 
+def test_downsample_no_offset_sharded_2x2x2():
+    layer_path = "downsample_no_offset_sharded_2x2x2"
+    delete_layer(layer_path)
+    cv, data = create_connectomics(layer_path)
+    
+    assert len(cv.scales) == 1
+    assert len(cv.available_mips) == 1
+
+    cv.commit_info()
+
+    tq = LocalTaskQueue()
+    tasks = create_image_shard_downsample_tasks(
+        cv.cloudpath, 
+        mip=0, 
+        num_mips=3, 
+        factor=(2,2,2),
+    )
+    tq.insert_all(tasks)
+
+    cv.refresh_info()
+
+    assert len(cv.available_mips) == 4
+    assert np.array_equal(cv.meta.volume_size(0), [ 512,  512, 512 ])
+    assert np.array_equal(cv.meta.volume_size(1), [ 256,  256, 256 ])
+    assert np.array_equal(cv.meta.volume_size(2), [ 128,  128, 128 ])
+    assert np.array_equal(cv.meta.volume_size(3), [  64,   64,  64 ])
+
+    cv.mip = 0
+    assert np.all(cv[:][...,0] == data)
+
+    data_ds = tinybrain.downsample_segmentation(data, factor=[2, 2, 2, 1], num_mips=3)
+    cv.mip = 1
+    labels = cv[:]
+    labels2 = data_ds[1][:]
+
+    assert np.all(cv[:][...,0] == data_ds[0][:])
+
+    cv.mip = 2
+    assert np.all(cv[:][...,0] == data_ds[1][:])
+
+    cv.mip = 3
+    assert np.all(cv[:][...,0] == data_ds[2][:])
+
+    delete_layer(layer_path)
+
 def test_downsample_with_offset():
     delete_layer()
     cf, data = create_layer(size=(512,512,128,1), offset=(3,7,11))

--- a/test/test_transfer_tasks.py
+++ b/test/test_transfer_tasks.py
@@ -10,7 +10,7 @@ import numpy as np
 from cloudvolume import CloudVolume, EmptyVolumeException
 import cloudvolume.lib as lib
 from cloudfiles import CloudFiles
-from taskqueue import MockTaskQueue, TaskQueue
+from taskqueue import LocalTaskQueue, TaskQueue
 import tinybrain
 
 import igneous
@@ -56,7 +56,7 @@ def rmsrc():
 
 @pytest.fixture(scope="module")
 def tq():
-  return MockTaskQueue()
+  return LocalTaskQueue()
 
 @pytest.fixture(scope="function")
 def src_cv(transfer_data):


### PR DESCRIPTION
Multi-mip sharded downsampling. Previously, only a single mip could be generated at a time.

The previous algorithm read 1-2 z chunks at a time, downsampled, and built a single shard. This allowed for reasonable memory consumption.

This new algorithm reads 1-2 chunks at a time, downsamples them, and stores them compressed in a dictionary. With more mip levels, the amount of image data grows tremendously, but for lossy compressed images or segmentation, compression will give a sufficient compression factor for this to be reasonable. E.g. segmentation can compress hundreds of times, lossy images can compress maybe 4-5x.

For losslessly compressed images, expect very large memory usage if using num_mips > 2. E.g. 16 + 4 + 1 = 21 shards * 0.7 = 14.7x.
