### PR TITLE
fix(cli): view of zarr data

### DIFF
--- a/igneous_cli/cli.py
+++ b/igneous_cli/cli.py
@@ -1696,12 +1696,16 @@ void main() {
       cv.meta.time_resolution_in_seconds(0), "s"
     ]
 
+  if isinstance(cv.meta, cloudvolume.datasource.zarr.ZarrMetadata):
+    source_format = "zarr"
+  else:
+    source_format = cv.meta.path.format
   config = {
     "dimensions": dimensions,
     "layers": [
       {
         "type": cv.layer_type,
-        "source": f"{cv.meta.path.format}://{cloudpath}",
+        "source": f"{source_format}://{cloudpath}",
         "tab": "source",
         "name": layer_name
       }


### PR DESCRIPTION
Closes #197

Semiclean solution for https://github.com/seung-lab/igneous/issues/197. 

I call it "semiclean" because think a cleaner approach may be to modify the logic of paths in `cloudvolume`. For instance this line is reached: https://github.com/seung-lab/cloud-volume/blob/74b3496d0d3a906cde6cac1d39fc3928360cfa93/cloudvolume/cloudvolume.py#L255 but the returned value is still a `CloudVolume` object such that `cv.meta.path.format == 'precomputed'`, while I would expect `cv.meta.path.format == 'zarr2'`

Since, since the PR only makes minimal changes, and only in the CLI function `view()` (which is therefore not called by other parts of the code), this workaround may be good enough.