### PR TITLE
perf: lower memory skeletonization

### DIFF
--- a/igneous/tasks/skeleton.py
+++ b/igneous/tasks/skeleton.py
@@ -406,7 +406,9 @@ class SkeletonTask(RegisteredTask):
     mapping = {}
 
     def download_all_labels():
+      nonlocal skeletons
       nonlocal mapping
+      
       all_labels, mapping = vol.download(big_bbox, renumber=True)
       all_labels = all_labels[...,0]
 
@@ -418,18 +420,17 @@ class SkeletonTask(RegisteredTask):
         object_ids = [ mapping[sid] for sid in self.object_ids ]
         all_labels = fastremap.mask_except(all_labels, object_ids, in_place=True)
 
-      return all_labels
-
-    def do_cross_section(labels):
-      nonlocal mapping
-      nonlocal skeletons
-
       skeletons = {
         mapping[sid]: skel 
         for sid, skel in skeletons.items()
       }
       for sid, skel in skeletons.items():
         skel.id = sid
+
+      return all_labels
+
+    def do_cross_section(labels):
+      nonlocal skeletons
 
       return kimimaro.cross_sectional_area(
         labels, skeletons,

--- a/igneous/tasks/skeleton.py
+++ b/igneous/tasks/skeleton.py
@@ -280,7 +280,7 @@ class SkeletonTask(RegisteredTask):
       del filled_labels
 
       all_labels = crackle.decompress(all_labels)
-      hole_labels = all_labels * np.isin(all_labels, list(hole_labels))
+      hole_labels = fastremap.mask_except(all_labels, list(hole_labels), in_place=True)
       del all_labels
       hole_skeletons = fn(hole_labels)
       skeletons.update(hole_skeletons)

--- a/igneous/tasks/skeleton.py
+++ b/igneous/tasks/skeleton.py
@@ -192,7 +192,6 @@ class SkeletonTask(RegisteredTask):
 
     if self.object_ids:
       self.object_ids = [ mapping[sid] for sid in self.object_ids ]
-    mapping = { v:k for k,v in mapping.items() }
 
     voxel_graph = None
     if self.fix_autapses:
@@ -211,9 +210,12 @@ class SkeletonTask(RegisteredTask):
       voxel_graph,
     )
     del all_labels
+    
+    mapping = { v:k for k,v in mapping.items() }
 
     if self.object_ids:
       self.object_ids = [ mapping[sid] for sid in self.object_ids ]
+
     skeletons = { mapping[sid]: skel for sid, skel in skeletons.items() }
     for sid, skel in skeletons.items():
       skel.id = sid

--- a/igneous/tasks/skeleton.py
+++ b/igneous/tasks/skeleton.py
@@ -1,6 +1,5 @@
 from typing import Optional, Sequence, Dict, List
 
-import copy
 from functools import reduce, partial
 import itertools
 import json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 click>=6.7
 cloud-files>=4.11.0
-cloud-volume[all_codecs]>=9.1.0
+cloud-volume[all_codecs]>=12.5.0
 crackle-codec
 connected-components-3d>=3.10.1
 dbscan
 DracoPy>=1.0.1,<2.0.0
-fastremap>=1.13.2
+fastremap>=1.17.4
 fastmorph>=1.4.1
 google-cloud-logging
 kimimaro[accel]>=5.4.0

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -623,7 +623,8 @@ def test_contrast_normalization_task():
 
 
 @pytest.mark.parametrize("cross_sectional_area", [False, True])
-def test_skeletonization_task(cross_sectional_area):
+@pytest.mark.parametrize("object_ids", [None, [2]])
+def test_skeletonization_task(cross_sectional_area, object_ids):
     directory = '/tmp/removeme/skeleton/'
     layer_path = 'file://' + directory
     delete_layer(layer_path)
@@ -644,6 +645,7 @@ def test_skeletonization_task(cross_sectional_area):
             'scale': 10,
             'const': 10,
         },
+        object_ids=object_ids,
         cross_sectional_area=cross_sectional_area,
         cross_sectional_area_smoothing_window=1,
     )


### PR DESCRIPTION
Uses CloudVolume renumbered downloads to reduce the size of the u64 labels and more carefully manages its lifecycle.

This was necessary because the addition of aggressive hole filling and cross section analysis were increasing the memory requirements such that out of memory errors were occurring during cluster processing.

This run seems to give fairly impressive results (blue) old code (black) new code

<img width="1720" height="966" alt="image (8)" src="https://github.com/user-attachments/assets/92baa4a9-25d6-4759-bf82-8ae54f5ce43b" />

This run is more ambiguous. (blue) old code (black) new code (red) new code. 

At least the initial download shows a benefit in memory consumption.

<img width="1260" height="540" alt="Figure_1" src="https://github.com/user-attachments/assets/6fac43a2-65ca-4297-be50-4a125c3a9fb7" />

